### PR TITLE
Make skip_final_snapshot a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Creates a RDS instance, security_group, subnet_group and parameter_group
 * [`project`]: String(required) the name of the project this RDS belongs to
 * [`environment`]: String(required) the name of the environment these subnets belong to (prod,stag,dev)
 * [`number`]: int(optional) number of the database (default 01)
+* [`skip_final_snapshot`]: bool(optional) Whether to skip creating a final snapshot when destroying the resource (default: false)
 * [`rds_parameter_group_name`]: String(required) the parameter group that is used for the db (supported: `mysql-rds-${var.project}-${var.environment}${var.tag}`, `oracle-rds-${var.project}-${var.environment}${var.tag}`,`postgres-rds-${var.project}-${var.environment}${var.tag}`)
 
 

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -86,23 +86,24 @@ resource "aws_db_parameter_group" "rds_postgres" {
 }
 
 resource "aws_db_instance" "rds" {
-  identifier              = "${var.project}-${var.environment}${var.tag}-rds${var.number}"
-  allocated_storage       = "${var.storage}"
-  engine                  = "${lookup(var.engines, var.rds_type)}"
-  engine_version          = "${lookup(var.engine_versions, var.rds_type)}"
-  instance_class          = "${var.size}"
-  storage_type            = "${var.storage_type}"
-  username                = "root"
-  password                = "${var.rds_password}"
-  vpc_security_group_ids  = ["${aws_security_group.sg_rds.id}"]
-  db_subnet_group_name    = "${aws_db_subnet_group.rds.id}"
-  parameter_group_name    = "${var.rds_parameter_group_name}"
-  multi_az                = "${var.multi_az}"
-  replicate_source_db     = "${var.replicate_source_db}"
-  backup_retention_period = "${var.backup_retention_period}"
-  storage_encrypted       = "${var.storage_encrypted}"
-  apply_immediately       = "${var.apply_immediately}"
-  skip_final_snapshot     = false
+  identifier                = "${var.project}-${var.environment}${var.tag}-rds${var.number}"
+  allocated_storage         = "${var.storage}"
+  engine                    = "${lookup(var.engines, var.rds_type)}"
+  engine_version            = "${lookup(var.engine_versions, var.rds_type)}"
+  instance_class            = "${var.size}"
+  storage_type              = "${var.storage_type}"
+  username                  = "root"
+  password                  = "${var.rds_password}"
+  vpc_security_group_ids    = ["${aws_security_group.sg_rds.id}"]
+  db_subnet_group_name      = "${aws_db_subnet_group.rds.id}"
+  parameter_group_name      = "${var.rds_parameter_group_name}"
+  multi_az                  = "${var.multi_az}"
+  replicate_source_db       = "${var.replicate_source_db}"
+  backup_retention_period   = "${var.backup_retention_period}"
+  storage_encrypted         = "${var.storage_encrypted}"
+  apply_immediately         = "${var.apply_immediately}"
+  skip_final_snapshot       = "${var.skip_final_snapshot}"
+  final_snapshot_identifier = "${var.project}-${var.environment}${var.tag}-rds${var.number}-final-${md5(timestamp())}"
 
   tags {
     Name        = "${var.project}-${var.environment}${var.tag}-rds${var.number}"

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -111,5 +111,9 @@ resource "aws_db_instance" "rds" {
     Project     = "${var.project}"
   }
 
+  lifecycle {
+    ignore_changes = ["final_snapshot_identifier"]
+  }
+
   depends_on = ["aws_db_parameter_group.rds_mysql", "aws_db_parameter_group.rds_oracle", "aws_db_parameter_group.rds_postgres"]
 }

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -4,7 +4,7 @@ variable "vpc_id" {
 
 variable "security_groups" {
   description = "Security groups that are allowed to access the RDS on port 3306"
-  type = "list"
+  type        = "list"
 }
 
 variable "subnets" {
@@ -78,10 +78,14 @@ variable "tag" {
 
 variable "number" {
   description = "number of the database default 01"
-  default = "01"
+  default     = "01"
 }
-
 
 variable "rds_parameter_group_name" {
   default = ""
+}
+
+variable "skip_final_snapshot" {
+  description = "Skip final snapshot when destorying RDS"
+  default     = false
 }


### PR DESCRIPTION
`skip_final_snapshot` is hardcoded to `false` but there is no `final_snapshot_identifier` defined, which can fail when trying to destroy the RDS instance.

This change defines an identifier and also makes the skip user settable.