### PR TITLE
Fixes for the instance and cluster paramters groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Creates a Aurora cluster + instances, security_group, subnet_group and parameter
 * [`project`]: String(required) the name of the project this RDS belongs to
 * [`environment`]: String(required) the name of the environment these subnets belong to (prod,stag,dev)
 * [`skip_final_snapshot`]: bool(optional) Whether to skip creating a final snapshot when destroying the resource (default: false)
-* [`rds_parameter_group_name`]: String(required) the parameter group that is used for the db (supported: `mysql-rds-${var.project}-${var.environment}${var.tag}`, `oracle-rds-${var.project}-${var.environment}${var.tag}`,`postgres-rds-${var.project}-${var.environment}${var.tag}`)
+* [`cluster_parameter_group_name`]: String(optional) the parameter group that is used for the cluster (default: The default aurora cluster group)
+* [`instance_parameter_group_name`]: String(optional) the parameter group that is used for the instances of the cluster (default: aurora-rds-${var.project}-${var.environment}${var.tag})
 * [`amount_of_instances`]: Integer(optional) How many aurora instances do you need, minimum 2 are needed for HA (default: 1)
 
 ### Output:

--- a/aurora/variables.tf
+++ b/aurora/variables.tf
@@ -58,11 +58,11 @@ variable "amount_of_instances" {
 }
 
 variable "cluster_parameter_group_name" {
-  description = "Optional parameter group you can set for the RDS cluster "
+  description = "Optional parameter group you can set for the RDS Aurora cluster "
   default = ""
 }
 
 variable "instance_parameter_group_name" {
-  description = "Optional parameter group you can set for the RDS cluster "
+  description = "Optional parameter group you can set for the RDS instances inside an Aurora cluster "
   default = ""
 }

--- a/aurora/variables.tf
+++ b/aurora/variables.tf
@@ -57,7 +57,12 @@ variable "amount_of_instances" {
   default     = 1
 }
 
-variable "rds_parameter_group_name" {
+variable "cluster_parameter_group_name" {
+  description = "Optional parameter group you can set for the RDS cluster "
+  default = ""
+}
+
+variable "instance_parameter_group_name" {
   description = "Optional parameter group you can set for the RDS cluster "
   default = ""
 }


### PR DESCRIPTION
The parameter groups in aurora are divided now in a cluster and instance parameter group.

The parameters we all set by default are all instance level ones. For the cluster I just use the default parameter group.