### PR TITLE
adding option to specify the snapshot_identifier in the RDS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Creates a RDS instance, security_group, subnet_group and parameter_group
 * [`skip_final_snapshot`]: bool(optional) Whether to skip creating a final snapshot when destroying the resource (default: false)
 * [`rds_custom_parameter_group_name`]: String(optional) A custom parameter group name to attach to the RDS instance. If not provided a default one will be created
 * [`availability_zone`]: string(optional) The availability zone where you want to launch your instance in
+* [`snapshot_identifier`]: string(optional) Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05.
 
 ### Output:
  * [`rds_port`]: String: The port of the rds

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -108,6 +108,7 @@ resource "aws_db_instance" "rds" {
   skip_final_snapshot       = "${var.skip_final_snapshot}"
   final_snapshot_identifier = "${var.project}-${var.environment}${var.tag}-rds${var.number}-final-${md5(timestamp())}"
   availability_zone         = "${var.availability_zone}"
+  snapshot_identifier       = "${var.snapshot_identifier}"
 
   tags {
     Name        = "${var.project}-${var.environment}${var.tag}-rds${var.number}"

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -97,6 +97,11 @@ variable "skip_final_snapshot" {
   description = "Skip final snapshot when destroying RDS"
   default     = false
 }
+
 variable "availability_zone" {
+  default = ""
+}
+
+variable "snapshot_identifier" {
   default = ""
 }


### PR DESCRIPTION
This PR is to add an additional feature that is allow an instance to be created from a snapshot.

This should not affect the existing module behaviour.

It has been tested on the tablebooker environment creating an instance with and without specifying a snapshot-id. Everything seems working fine.