### PR TITLE
adding option to specify username

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Creates a RDS instance, security_group, subnet_group and parameter_group
 * [`rds_custom_parameter_group_name`]: String(optional) A custom parameter group name to attach to the RDS instance. If not provided a default one will be created
 * [`availability_zone`]: string(optional) The availability zone where you want to launch your instance in
 * [`snapshot_identifier`]: string(optional) Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05.
+* [`username`]: string(optional) The admin username of the database (default:root)
 
 ### Output:
  * [`rds_port`]: String: The port of the rds
@@ -67,6 +68,7 @@ Creates a Aurora cluster + instances, security_group, subnet_group and parameter
 * [`cluster_parameter_group_name`]: String(optional) the parameter group that is used for the cluster (default: The default aurora cluster group)
 * [`instance_parameter_group_name`]: String(optional) the parameter group that is used for the instances of the cluster (default: aurora-rds-${var.project}-${var.environment}${var.tag})
 * [`amount_of_instances`]: Integer(optional) How many aurora instances do you need, minimum 2 are needed for HA (default: 1)
+* [`username`]: string(optional) The admin username of the database (default:root)
 
 ### Output:
  * [`aurora_port`]: String: The port of the rds

--- a/aurora/main.tf
+++ b/aurora/main.tf
@@ -40,7 +40,7 @@ resource "aws_db_parameter_group" "aurora_mysql" {
 
 resource "aws_rds_cluster" "aurora" {
   cluster_identifier              = "${var.project}-${var.environment}${var.tag}-aurora"
-  master_username                 = "root"
+  master_username                 = "${var.username}"
   master_password                 = "${var.password}"
   backup_retention_period         = "${var.backup_retention_period}"
   skip_final_snapshot             = "${var.skip_final_snapshot}"

--- a/aurora/variables.tf
+++ b/aurora/variables.tf
@@ -66,3 +66,7 @@ variable "instance_parameter_group_name" {
   description = "Optional parameter group you can set for the RDS instances inside an Aurora cluster "
   default = ""
 }
+
+variable "username" {
+  default = "root"
+}

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -95,7 +95,7 @@ resource "aws_db_instance" "rds" {
   engine_version            = "${lookup(var.engine_versions, var.rds_type)}"
   instance_class            = "${var.size}"
   storage_type              = "${var.storage_type}"
-  username                  = "root"
+  username                  = "${var.username}"
   password                  = "${var.rds_password}"
   vpc_security_group_ids    = ["${aws_security_group.sg_rds.id}"]
   db_subnet_group_name      = "${aws_db_subnet_group.rds.id}"

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -105,3 +105,7 @@ variable "availability_zone" {
 variable "snapshot_identifier" {
   default = ""
 }
+
+variable "username" {
+  default = "root"
+}


### PR DESCRIPTION
We currently cannot specify a root user. Sometimes it might be useful to have the option to specify a different root user.