### PR TITLE
Refactored a bit the rds module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Creates a RDS instance, security_group, subnet_group and parameter_group
 * [`size`]: String(optional) RDS instance size
 * [`storage_type`]: String(optional) Type of storage you want to use
 * [`rds_password`]: String(required) RDS root password
-* [`rds_type`]: String(optional) RDS type: `mysql`, `postgres` or `oracle` (default: `mysql`)
+* [`engine`]: String(optional) RDS engine: `mysql`, `postgres` or `oracle` (default: `mysql`)
+* [`engine_version`]: String(optional) Engine version to use, according to the chosen engine. You can check the available engine versions using the AWS CLI (http://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html) (default: `5.7.17` - for MySQL)
+* [`default_parameter_group_family`]: String(optional) Parameter group family for the default parameter group, according to the chosen engine and engine version. Will be omitted if `rds_custom_parameter_group_name` is provided (default: `mysql5.7`)
 * [`replicate_source_db`]: String(optional) RDS source to replicate from
 * [`multi_az`]: bool(optional) Multi AZ for RDS master (default: true)
 * [`backup_retention_period`]: int(optional) How long do you want to keep RDS backups (default: 14)

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -1,105 +1,68 @@
 #lookup parameters for specic RDS types
-variable "ports" {
+variable "default_db_parameters" {
+  default = {
+    mysql = [
+      {
+        name  = "slow_query_log"
+        value = "1"
+      },
+      {
+        name  = "long_query_time"
+        value = "1"
+      },
+      {
+        name  = "general_log"
+        value = "0"
+      },
+      {
+        name  = "log_output"
+        value = "FILE"
+      },
+    ]
+
+    postgres = []
+    oracle   = []
+  }
+}
+
+variable "default_ports" {
   default = {
     mysql    = "3306"
-    oracle   = "1521"
     postgres = "5432"
+    oracle   = "1521"
   }
 }
 
-variable "families" {
-  default = {
-    mysql    = "mysql5.6"
-    oracle   = "oracle-se2-12.1"
-    postgres = "postgres9.5"
-  }
-}
-
-variable "engines" {
-  default = {
-    mysql    = "mysql"
-    oracle   = "oracle-se2"
-    postgres = "postgres"
-  }
-}
-
-variable "engine_versions" {
-  default = {
-    mysql    = "5.6.22"
-    oracle   = "12.1.0.2.v2"
-    postgres = "9.5.4"
-  }
+locals {
+  port = "${var.default_ports[var.engine]}"
 }
 
 resource "aws_db_subnet_group" "rds" {
-  name        = "${var.project}-${var.environment}${var.tag}-rds"
-  description = "Our main group of subnets"
+  name_prefix = "${var.project}-${var.environment}${var.tag}-"
+  description = "RDS subnet group"
   subnet_ids  = ["${var.subnets}"]
 }
 
-resource "aws_db_parameter_group" "rds_mysql" {
-  count       = "${var.rds_type == "mysql" && length(var.rds_custom_parameter_group_name) == 0 ? 1 : 0}"
-  name        = "mysql-rds-${var.project}-${var.environment}${var.tag}"
-  family      = "${lookup(var.families, "mysql")}"
-  description = "rds ${var.project} ${var.environment} parameter group for mysql"
-
-  parameter = {
-    name = "slow_query_log"
-
-    value = "1"
-  }
-
-  parameter = {
-    name = "long_query_time"
-
-    value = "1"
-  }
-
-  parameter = {
-    name = "general_log"
-
-    value = "0"
-  }
-
-  parameter = {
-    name = "log_output"
-
-    value = "FILE"
-  }
-}
-
-resource "aws_db_parameter_group" "rds_oracle" {
-  count       = "${var.rds_type == "oracle" && length(var.rds_custom_parameter_group_name) == 0 ? 1 : 0}"
-  name        = "oracle-rds-${var.project}-${var.environment}${var.tag}"
-  family      = "${lookup(var.families, "oracle")}"
-  description = "rds ${var.project} ${var.environment} parameter group for oracle"
-
-  parameter = {
-    name = "db_block_checking"
-
-    value = "MEDIUM"
-  }
-}
-
-resource "aws_db_parameter_group" "rds_postgres" {
-  count       = "${var.rds_type == "postgres" && length(var.rds_custom_parameter_group_name) == 0 ? 1 : 0}"
-  name        = "postgres-rds-${var.project}-${var.environment}${var.tag}"
-  family      = "${lookup(var.families, "postgres")}"
-  description = "rds ${var.project} ${var.environment} parameter group for postgres"
+resource "aws_db_parameter_group" "rds" {
+  count       = "${length(var.rds_custom_parameter_group_name) == 0 ? 1 : 0}"
+  name_prefix = "${var.engine}-${var.project}-${var.environment}${var.tag}-"
+  family      = "${var.default_parameter_group_family}"
+  description = "RDS ${var.project} ${var.environment} parameter group for ${var.engine}"
+  parameter   = "${var.default_db_parameters[var.engine]}"
 }
 
 resource "aws_db_instance" "rds" {
   identifier                = "${var.project}-${var.environment}${var.tag}-rds${var.number}"
   allocated_storage         = "${var.storage}"
-  engine                    = "${lookup(var.engines, var.rds_type)}"
-  engine_version            = "${lookup(var.engine_versions, var.rds_type)}"
+  engine                    = "${var.engine}"
+  engine_version            = "${var.engine_version}"
   instance_class            = "${var.size}"
   storage_type              = "${var.storage_type}"
   username                  = "root"
   password                  = "${var.rds_password}"
   vpc_security_group_ids    = ["${aws_security_group.sg_rds.id}"]
   db_subnet_group_name      = "${aws_db_subnet_group.rds.id}"
-  parameter_group_name      = "${length(var.rds_custom_parameter_group_name) > 0 ? var.rds_custom_parameter_group_name : join("", aws_db_parameter_group.rds_mysql.*.name, aws_db_parameter_group.rds_oracle.*.name, aws_db_parameter_group.rds_postgres.*.name)}"
+  parameter_group_name      = "${length(var.rds_custom_parameter_group_name) > 0 ? var.rds_custom_parameter_group_name : aws_db_parameter_group.rds.name}"
   multi_az                  = "${var.multi_az}"
   replicate_source_db       = "${var.replicate_source_db}"
   backup_retention_period   = "${var.backup_retention_period}"

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -38,8 +38,8 @@ locals {
 }
 
 resource "aws_db_subnet_group" "rds" {
-  name_prefix = "${var.project}-${var.environment}${var.tag}-"
-  description = "RDS subnet group"
+  name        = "${var.project}-${var.environment}${var.tag}-rds"
+  description = "Our main group of subnets"
   subnet_ids  = ["${var.subnets}"]
 }
 

--- a/rds/outputs.tf
+++ b/rds/outputs.tf
@@ -1,5 +1,5 @@
 output "rds_port" {
-  value = "${lookup(var.ports, var.rds_type)}"
+  value = "${local.port}"
 }
 
 output "rds_address" {

--- a/rds/security_group.tf
+++ b/rds/security_group.tf
@@ -15,8 +15,8 @@ resource "aws_security_group_rule" "rds_sg_in" {
   count                    = "${length(var.security_groups)}"
   security_group_id        = "${aws_security_group.sg_rds.id}"
   type                     = "ingress"
-  from_port                = "${lookup(var.ports, var.rds_type)}"
-  to_port                  = "${lookup(var.ports, var.rds_type)}"
+  from_port                = "${local.port}"
+  to_port                  = "${local.port}"
   protocol                 = "tcp"
   source_security_group_id = "${element(var.security_groups, count.index)}"
 }
@@ -25,8 +25,8 @@ resource "aws_security_group_rule" "rds_cidr_in" {
   count             = "${length(var.allowed_cidr_blocks) == 0 ? 0 : 1}"
   security_group_id = "${aws_security_group.sg_rds.id}"
   type              = "ingress"
-  from_port         = "${lookup(var.ports, var.rds_type)}"
-  to_port           = "${lookup(var.ports, var.rds_type)}"
+  from_port         = "${local.port}"
+  to_port           = "${local.port}"
   protocol          = "tcp"
   cidr_blocks       = ["${var.allowed_cidr_blocks}"]
 }

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -38,9 +38,19 @@ variable "rds_password" {
   description = "RDS root password"
 }
 
-variable "rds_type" {
-  description = "RDS type: mysql, oracle, postgres"
+variable "engine" {
+  description = "RDS engine: mysql, oracle, postgres. Defaults to mysql"
   default     = "mysql"
+}
+
+variable "engine_version" {
+  description = "Engine version to use, according to the chosen engine. You can check the available engine versions using the AWS CLI (http://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html). Defaults to 5.7.17 for MySQL."
+  default     = "5.7.17"
+}
+
+variable "default_parameter_group_family" {
+  description = "Parameter group family for the default parameter group, according to the chosen engine and engine version. Will be omitted if `rds_custom_parameter_group_name` is provided. Defaults to mysql5.7"
+  default     = "mysql5.7"
 }
 
 variable "replicate_source_db" {
@@ -99,9 +109,11 @@ variable "skip_final_snapshot" {
 }
 
 variable "availability_zone" {
-  default = ""
+  description = "The availability zone where you want to launch your instance in"
+  default     = ""
 }
 
 variable "snapshot_identifier" {
-  default = ""
+  description = "Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05."
+  default     = ""
 }


### PR DESCRIPTION
It now requires the module user to be a bit more explicit when specifying engines and engine versions.

It previously assumed some parameters like engine versions and parameter group families according to the provided engine, and it was too cumbersome (and not documented) to override those.

Also changed parameter name `rds_type` to `engine`, which seemed more appropriate.

Will bump major version for this. For existing setups, it'll only re-create the db parameter group, which shouldn't cause any downtime.