### PR TITLE
Default RDS storage type to gp2 instead of standard (deprecated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Creates a RDS instance, security_group, subnet_group and parameter_group
 * [`subnets`]: List(required) Subnets to deploy the RDS in
 * [`storage`]: String(optional) How many GBs of space does your database need?
 * [`size`]: String(optional) RDS instance size
-* [`storage_type`]: String(optional) Type of storage you want to use
+* [`storage_type`]: String(optional) Type of storage you want to use (default: `gp2`)
 * [`rds_password`]: String(required) RDS root password
 * [`engine`]: String(optional) RDS engine: `mysql`, `postgres` or `oracle` (default: `mysql`)
 * [`engine_version`]: String(optional) Engine version to use, according to the chosen engine. You can check the available engine versions using the AWS CLI (http://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html) (default: `5.7.17` - for MySQL)

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -31,7 +31,7 @@ variable "size" {
 
 variable "storage_type" {
   description = "Type of storage you want to use"
-  default     = "standard"
+  default     = "gp2"
 }
 
 variable "rds_password" {


### PR DESCRIPTION
Because `standard` is deprecated and we shouldn't use magnetic storage anyway, unless there's a specific need for it.