### PR TITLE
adding root username parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Creates a RDS instance, security_group, subnet_group and parameter_group
 * [`size`]: String(optional) RDS instance size
 * [`storage_type`]: String(optional) Type of storage you want to use (default: `gp2`)
 * [`rds_password`]: String(required) RDS root password
+* [`rds_username`]: String(optional) RDS root user (default: `root`)
 * [`engine`]: String(optional) RDS engine: `mysql`, `postgres` or `oracle` (default: `mysql`)
 * [`engine_version`]: String(optional) Engine version to use, according to the chosen engine. You can check the available engine versions using the AWS CLI (http://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html) (default: `5.7.17` - for MySQL)
 * [`default_parameter_group_family`]: String(optional) Parameter group family for the default parameter group, according to the chosen engine and engine version. Will be omitted if `rds_custom_parameter_group_name` is provided (default: `mysql5.7`)
@@ -59,6 +60,7 @@ Creates a Aurora cluster + instances, security_group, subnet_group and parameter
 * [`subnets`]: List(required) Subnets to deploy the RDS in
 * [`size`]: String(optional) RDS instance size
 * [`password`]: String(required) RDS root password
+* [`rds_username`]: String(optional) RDS root user (default: `root`)
 * [`backup_retention_period`]: int(optional) How long do you want to keep RDS backups (default: 14)
 * [`apply_immediately`]: bool(optional) whether you want to Apply changes immediately (default: true)
 * [`storage_encrypted`]: bool(optional) whether you want to Encrypt RDS storage (default: true)

--- a/aurora/main.tf
+++ b/aurora/main.tf
@@ -40,8 +40,8 @@ resource "aws_db_parameter_group" "aurora_mysql" {
 
 resource "aws_rds_cluster" "aurora" {
   cluster_identifier              = "${var.project}-${var.environment}${var.tag}-aurora"
-  master_username                 = "root"
-  master_password                 = "${var.password}"
+  master_username                 = "${var.master_username}"
+  master_password                 = "${var.rds_username}"
   backup_retention_period         = "${var.backup_retention_period}"
   skip_final_snapshot             = "${var.skip_final_snapshot}"
   final_snapshot_identifier       = "${var.project}-${var.environment}${var.tag}-aurora-final-${md5(timestamp())}"

--- a/aurora/main.tf
+++ b/aurora/main.tf
@@ -40,8 +40,8 @@ resource "aws_db_parameter_group" "aurora_mysql" {
 
 resource "aws_rds_cluster" "aurora" {
   cluster_identifier              = "${var.project}-${var.environment}${var.tag}-aurora"
-  master_username                 = "${var.master_username}"
-  master_password                 = "${var.rds_username}"
+  master_username                 = "${var.rds_username}"
+  master_password                 = "${var.password}"
   backup_retention_period         = "${var.backup_retention_period}"
   skip_final_snapshot             = "${var.skip_final_snapshot}"
   final_snapshot_identifier       = "${var.project}-${var.environment}${var.tag}-aurora-final-${md5(timestamp())}"

--- a/aurora/variables.tf
+++ b/aurora/variables.tf
@@ -17,6 +17,11 @@ variable "password" {
   description = "RDS root password"
 }
 
+variable "rds_username" {
+  description = "RDS root user"
+  default = "root"
+}
+
 variable "backup_retention_period" {
   description = "How long do you want to keep RDS backups"
   default     = "14"

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -58,7 +58,7 @@ resource "aws_db_instance" "rds" {
   engine_version            = "${var.engine_version}"
   instance_class            = "${var.size}"
   storage_type              = "${var.storage_type}"
-  username                  = "root"
+  username                  = "${var.rds_username}"
   password                  = "${var.rds_password}"
   vpc_security_group_ids    = ["${aws_security_group.sg_rds.id}"]
   db_subnet_group_name      = "${aws_db_subnet_group.rds.id}"

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -38,6 +38,11 @@ variable "rds_password" {
   description = "RDS root password"
 }
 
+variable "rds_username" {
+  description = "RDS root user"
+  default = "root"
+}
+
 variable "engine" {
   description = "RDS engine: mysql, oracle, postgres. Defaults to mysql"
   default     = "mysql"


### PR DESCRIPTION
We currently cannot specify a root user. Sometimes it might be useful to have the option to specify a different root user.

An example is when we import from a snapshot that has already an existing different root user.