### PR TITLE
adding option to specify aurora db family

### DIFF
--- a/aurora/main.tf
+++ b/aurora/main.tf
@@ -11,7 +11,7 @@ resource "aws_db_subnet_group" "aurora" {
 resource "aws_db_parameter_group" "aurora_mysql" {
   count       = "${length(var.instance_parameter_group_name) == 0 ? 1 : 0}"
   name        = "aurora-rds-${var.project}-${var.environment}${var.tag}"
-  family      = "aurora5.6"
+  family      = "${var.family}"
   description = "aurora ${var.project} ${var.environment} parameter group for mysql"
 
   parameter = {

--- a/aurora/variables.tf
+++ b/aurora/variables.tf
@@ -81,3 +81,7 @@ variable "engine_version" {
   description = "Optional parameter to set the Aurora engine version"
   default = "5.6.10a"
 }
+
+variable "family" {
+  default = "aurora5.6"
+}


### PR DESCRIPTION
# Why?

1) Hardcode a version in a module is never a good thing to do
2) We need to be able to use version 5.7