### PR TITLE
adding option to set name for rds instance and related components

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Creates a RDS instance, security_group, subnet_group and parameter_group
 * [`rds_custom_parameter_group_name`]: String(optional) A custom parameter group name to attach to the RDS instance. If not provided a default one will be created
 * [`availability_zone`]: string(optional) The availability zone where you want to launch your instance in
 * [`snapshot_identifier`]: string(optional) Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05.
+* [`name`]: string(optional) name of the resourced (default to <project>-<environment><tag>-rds<number>)
 
 ### Output:
  * [`rds_port`]: String: The port of the rds

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Creates a RDS instance, security_group, subnet_group and parameter_group
 * [`rds_username`]: String(optional) RDS root user (default: `root`)
 * [`engine`]: String(optional) RDS engine: `mysql`, `postgres` or `oracle` (default: `mysql`)
 * [`engine_version`]: String(optional) Engine version to use, according to the chosen engine. You can check the available engine versions using the AWS CLI (http://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html) (default: `5.7.17` - for MySQL)
-* [`default_parameter_group_family`]: String(optional) Parameter group family for the default parameter group, according to the chosen engine and engine version. Will be omitted if `rds_custom_parameter_group_name` is provided (default: `mysql5.7`)
+* [`default_parameter_group_family`]: String(optional) Parameter group family for the default parameter group, according to the chosen engine and engine version. Defaults to `mysql5.7`
 * [`replicate_source_db`]: String(optional) RDS source to replicate from
 * [`multi_az`]: bool(optional) Multi AZ for RDS master (default: true)
 * [`backup_retention_period`]: int(optional) How long do you want to keep RDS backups (default: 14)
@@ -27,10 +27,10 @@ Creates a RDS instance, security_group, subnet_group and parameter_group
 * [`environment`]: String(required) the name of the environment these subnets belong to (prod,stag,dev)
 * [`number`]: int(optional) number of the database (default 01)
 * [`skip_final_snapshot`]: bool(optional) Whether to skip creating a final snapshot when destroying the resource (default: false)
-* [`rds_custom_parameter_group_name`]: String(optional) A custom parameter group name to attach to the RDS instance. If not provided a default one will be created
+* [`rds_custom_parameter_group_name`]: String(optional) A custom parameter group name to attach to the RDS instance. If not provided a default one will be used
 * [`availability_zone`]: string(optional) The availability zone where you want to launch your instance in
 * [`snapshot_identifier`]: string(optional) Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05.
-* [`name`]: string(optional) name of the resources (default to <project>-<environment><tag>-rds<number>)
+* [`name`]: String(optional) Name of the resources (default to <project>-<environment><tag>-rds<number>)
 
 ### Output:
  * [`rds_port`]: String: The port of the rds

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Creates a RDS instance, security_group, subnet_group and parameter_group
 * [`rds_custom_parameter_group_name`]: String(optional) A custom parameter group name to attach to the RDS instance. If not provided a default one will be created
 * [`availability_zone`]: string(optional) The availability zone where you want to launch your instance in
 * [`snapshot_identifier`]: string(optional) Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05.
-* [`name`]: string(optional) name of the resourced (default to <project>-<environment><tag>-rds<number>)
+* [`name`]: string(optional) name of the resources (default to <project>-<environment><tag>-rds<number>)
 
 ### Output:
  * [`rds_port`]: String: The port of the rds
@@ -108,11 +108,12 @@ Creates an RDS read replica instance,the replica security_group and a subnet_gro
 * [`size`]: String(optional) RDS instance size
 * [`engine`]: String(required) RDS type: `mysql`, `postgres` or `oracle`
 * [`replicate_source_db`]: String(required) RDS source to replicate from. NOTE: this must be the ARN of the instance, otherwise you cannot specify the db_subnet_group_name
-* [`name`]: String(optional) the name of the replica
+* [`tag`]: String(optional) the tag of the replica
 * [`project`]: String(required) the name of the project this RDS belongs to
 * [`environment`]: String(required) the name of the environment these subnets belong to (prod,stag,dev)
 * [`number`]: int(optional) number of the replica (default 01)
 * [`availability_zone`]: string(optional) The availability zone where you want to launch your instance in
+* [`name`]: string(optional) name of the resources (default to <project>-<environment><tag>-rds<number>-replica)
 
 ### Output:
  * [`rds_address`]: String: The hostname of the rds instance

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Creates an RDS read replica instance,the replica security_group and a subnet_gro
 * [`number`]: int(optional) number of the replica (default 01)
 * [`availability_zone`]: string(optional) The availability zone where you want to launch your instance in
 * [`name`]: string(optional) name of the resources (default to <project>-<environment><tag>-rds<number>-replica)
+* [`storage_encrypted`]: bool(optional) whether you want to Encrypt RDS storage (default: true)
 
 ### Output:
  * [`rds_address`]: String: The hostname of the rds instance

--- a/rds-replica/main.tf
+++ b/rds-replica/main.tf
@@ -10,7 +10,7 @@ resource "aws_db_instance" "rds" {
   instance_class            = "${var.size}"
   vpc_security_group_ids    = ["${aws_security_group.sg_rds.id}"]
   replicate_source_db       = "${var.replicate_source_db}"
-  final_snapshot_identifier = "${var.project}-${var.environment}${var.tag}-rds${var.number}-final-${md5(timestamp())}"
+  final_snapshot_identifier = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}" : var.name}-replica-final-${md5(timestamp())}"
   db_subnet_group_name      = "${aws_db_subnet_group.rds.id}"
 
   tags {

--- a/rds-replica/main.tf
+++ b/rds-replica/main.tf
@@ -12,6 +12,7 @@ resource "aws_db_instance" "rds" {
   replicate_source_db       = "${var.replicate_source_db}"
   final_snapshot_identifier = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}" : var.name}-replica-final-${md5(timestamp())}"
   db_subnet_group_name      = "${aws_db_subnet_group.rds.id}"
+  storage_encrypted         = "${var.storage_encrypted}"
 
   tags {
     tag        = "${length(var.name)==0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica" : var.name}"

--- a/rds-replica/main.tf
+++ b/rds-replica/main.tf
@@ -1,20 +1,20 @@
 resource "aws_db_subnet_group" "rds" {
-  tag        = "replica-${var.environment}${var.tag}-rds"
+  name        = "${length(var.name)==0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica" : var.name}"
   description = "The group of subnets"
   subnet_ids  = ["${var.subnets}"]
 }
 
 resource "aws_db_instance" "rds" {
-  identifier                = "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica"
+  identifier                = "${length(var.name)==0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica" : var.name}"
   engine                    = "${var.engine}"
   instance_class            = "${var.size}"
   vpc_security_group_ids    = ["${aws_security_group.sg_rds.id}"]
   replicate_source_db       = "${var.replicate_source_db}"
   final_snapshot_identifier = "${var.project}-${var.environment}${var.tag}-rds${var.number}-final-${md5(timestamp())}"
-  db_subnet_group_tag      = "${aws_db_subnet_group.rds.id}"
+  db_subnet_group_name      = "${aws_db_subnet_group.rds.id}"
 
   tags {
-    tag        = "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica"
+    tag        = "${length(var.name)==0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica" : var.name}"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }

--- a/rds-replica/main.tf
+++ b/rds-replica/main.tf
@@ -1,20 +1,20 @@
 resource "aws_db_subnet_group" "rds" {
-  name        = "replica-${var.environment}${var.name}-rds"
+  tag        = "replica-${var.environment}${var.tag}-rds"
   description = "The group of subnets"
   subnet_ids  = ["${var.subnets}"]
 }
 
 resource "aws_db_instance" "rds" {
-  identifier                = "${var.project}-${var.environment}${var.name}-rds${var.number}-replica"
+  identifier                = "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica"
   engine                    = "${var.engine}"
   instance_class            = "${var.size}"
   vpc_security_group_ids    = ["${aws_security_group.sg_rds.id}"]
   replicate_source_db       = "${var.replicate_source_db}"
-  final_snapshot_identifier = "${var.project}-${var.environment}${var.name}-rds${var.number}-final-${md5(timestamp())}"
-  db_subnet_group_name      = "${aws_db_subnet_group.rds.id}"
+  final_snapshot_identifier = "${var.project}-${var.environment}${var.tag}-rds${var.number}-final-${md5(timestamp())}"
+  db_subnet_group_tag      = "${aws_db_subnet_group.rds.id}"
 
   tags {
-    Name        = "${var.project}-${var.environment}${var.name}-rds${var.number}-replica"
+    tag        = "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }

--- a/rds-replica/main.tf
+++ b/rds-replica/main.tf
@@ -1,11 +1,11 @@
 resource "aws_db_subnet_group" "rds" {
-  name        = "${length(var.name)==0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica" : var.name}"
+  name        = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica" : var.name}"
   description = "The group of subnets"
   subnet_ids  = ["${var.subnets}"]
 }
 
 resource "aws_db_instance" "rds" {
-  identifier                = "${length(var.name)==0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica" : var.name}"
+  identifier                = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica" : var.name}"
   engine                    = "${var.engine}"
   instance_class            = "${var.size}"
   vpc_security_group_ids    = ["${aws_security_group.sg_rds.id}"]
@@ -15,7 +15,7 @@ resource "aws_db_instance" "rds" {
   storage_encrypted         = "${var.storage_encrypted}"
 
   tags {
-    tag        = "${length(var.name)==0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica" : var.name}"
+    Name        = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica" : var.name}"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }

--- a/rds-replica/security_group.tf
+++ b/rds-replica/security_group.tf
@@ -8,12 +8,12 @@ variable "ports" {
 
 # Create RDS with Subnet and paramter group,
 resource "aws_security_group" "sg_rds" {
-  name        = "sg_rds_replica_${var.project}_${var.environment}${var.name}"
+  name        = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-replica" : var.name}-sg-rds"
   description = "Security group that is needed for the RDS replica"
   vpc_id      = "${var.vpc_id}"
 
   tags {
-    Name        = "${var.project}-${var.environment}${var.name}-sg_rds_replica"
+    Name        = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-replica" : var.name}-sg-rds"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }

--- a/rds-replica/variables.tf
+++ b/rds-replica/variables.tf
@@ -41,8 +41,8 @@ variable "environment" {
   default     = "production"
 }
 
-variable "name" {
-  description = "A name used to identify an RDS in a project that has more than one RDS"
+variable "tag" {
+  description = "A tag used to identify an RDS in a project that has more than one RDS"
   default     = ""
 }
 
@@ -52,5 +52,10 @@ variable "number" {
 }
 
 variable "availability_zone" {
+  default = ""
+}
+
+variable "name" {
+  description = "An optional custom name to give to the module's resources"
   default = ""
 }

--- a/rds-replica/variables.tf
+++ b/rds-replica/variables.tf
@@ -59,3 +59,8 @@ variable "name" {
   description = "An optional custom name to give to the module's resources"
   default = ""
 }
+
+variable "storage_encrypted" {
+  description = "Encrypt RDS storage"
+  default     = true
+}

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -38,21 +38,21 @@ locals {
 }
 
 resource "aws_db_subnet_group" "rds" {
-  name        = "${var.project}-${var.environment}${var.tag}-rds"
+  name        = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds" : var.name}"
   description = "Our main group of subnets"
   subnet_ids  = ["${var.subnets}"]
 }
 
 resource "aws_db_parameter_group" "rds" {
   count       = "${length(var.rds_custom_parameter_group_name) == 0 ? 1 : 0}"
-  name_prefix = "${var.engine}-${var.project}-${var.environment}${var.tag}-"
+  name_prefix = "${length(var.name) == 0 ? "${var.engine}-${var.project}-${var.environment}${var.tag}" : var.name}-"
   family      = "${var.default_parameter_group_family}"
   description = "RDS ${var.project} ${var.environment} parameter group for ${var.engine}"
   parameter   = "${var.default_db_parameters[var.engine]}"
 }
 
 resource "aws_db_instance" "rds" {
-  identifier                = "${var.project}-${var.environment}${var.tag}-rds${var.number}"
+  identifier                = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}" : var.name}"
   allocated_storage         = "${var.storage}"
   engine                    = "${var.engine}"
   engine_version            = "${var.engine_version}"
@@ -74,7 +74,7 @@ resource "aws_db_instance" "rds" {
   snapshot_identifier       = "${var.snapshot_identifier}"
 
   tags {
-    Name        = "${var.project}-${var.environment}${var.tag}-rds${var.number}"
+    Name        = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}" : var.name}"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -69,7 +69,7 @@ resource "aws_db_instance" "rds" {
   storage_encrypted         = "${var.storage_encrypted}"
   apply_immediately         = "${var.apply_immediately}"
   skip_final_snapshot       = "${var.skip_final_snapshot}"
-  final_snapshot_identifier = "${var.project}-${var.environment}${var.tag}-rds${var.number}-final-${md5(timestamp())}"
+  final_snapshot_identifier = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}" : var.name}-final-${md5(timestamp())}"
   availability_zone         = "${var.availability_zone}"
   snapshot_identifier       = "${var.snapshot_identifier}"
 

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -44,8 +44,7 @@ resource "aws_db_subnet_group" "rds" {
 }
 
 resource "aws_db_parameter_group" "rds" {
-  count       = "${length(var.rds_custom_parameter_group_name) == 0 ? 1 : 0}"
-  name_prefix = "${length(var.name) == 0 ? "${var.engine}-${var.project}-${var.environment}${var.tag}" : var.name}-"
+  name_prefix = "${length(var.name) == 0 ? "default-${var.engine}-${var.project}-${var.environment}${var.tag}" : "default-${var.name}"}-"
   family      = "${var.default_parameter_group_family}"
   description = "RDS ${var.project} ${var.environment} parameter group for ${var.engine}"
   parameter   = "${var.default_db_parameters[var.engine]}"
@@ -62,7 +61,7 @@ resource "aws_db_instance" "rds" {
   password                  = "${var.rds_password}"
   vpc_security_group_ids    = ["${aws_security_group.sg_rds.id}"]
   db_subnet_group_name      = "${aws_db_subnet_group.rds.id}"
-  parameter_group_name      = "${length(var.rds_custom_parameter_group_name) > 0 ? var.rds_custom_parameter_group_name : aws_db_parameter_group.rds.name}"
+  parameter_group_name      = "${var.rds_custom_parameter_group_name == "" ? aws_db_parameter_group.rds.id : var.rds_custom_parameter_group_name}"
   multi_az                  = "${var.multi_az}"
   replicate_source_db       = "${var.replicate_source_db}"
   backup_retention_period   = "${var.backup_retention_period}"

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -44,7 +44,7 @@ resource "aws_db_subnet_group" "rds" {
 }
 
 resource "aws_db_parameter_group" "rds" {
-  name_prefix = "${length(var.name) == 0 ? "default-${var.engine}-${var.project}-${var.environment}${var.tag}" : "default-${var.name}"}-"
+  name_prefix = "${length(var.name) == 0 ? "${var.engine}-${var.project}-${var.environment}${var.tag}" : "${var.name}"}-"
   family      = "${var.default_parameter_group_family}"
   description = "RDS ${var.project} ${var.environment} parameter group for ${var.engine}"
   parameter   = "${var.default_db_parameters[var.engine]}"

--- a/rds/security_group.tf
+++ b/rds/security_group.tf
@@ -1,11 +1,11 @@
 # Create RDS with Subnet and paramter group,
 resource "aws_security_group" "sg_rds" {
-  name        = "sg_rds_${var.project}_${var.environment}${var.tag}"
+  name        = "${length(var.name) ==0 ? "${var.project}-${var.environment}${var.tag}" : var.name}-rds"
   description = "Security group that is needed for the RDS"
   vpc_id      = "${var.vpc_id}"
 
   tags {
-    Name        = "${var.project}-${var.environment}${var.tag}-sg_rds"
+    Name        = "${length(var.name) ==0 ? "${var.project}-${var.environment}${var.tag}" : var.name}-rds"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }

--- a/rds/security_group.tf
+++ b/rds/security_group.tf
@@ -1,11 +1,11 @@
 # Create RDS with Subnet and paramter group,
 resource "aws_security_group" "sg_rds" {
-  name        = "${length(var.name) ==0 ? "${var.project}-${var.environment}${var.tag}" : var.name}-rds"
+  name        = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}" : var.name}-rds"
   description = "Security group that is needed for the RDS"
   vpc_id      = "${var.vpc_id}"
 
   tags {
-    Name        = "${length(var.name) ==0 ? "${var.project}-${var.environment}${var.tag}" : var.name}-rds"
+    Name        = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}" : var.name}-rds"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -122,3 +122,8 @@ variable "snapshot_identifier" {
   description = "Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05."
   default     = ""
 }
+
+variable "name" {
+  description = "The name of the RDS instance"
+  default = ""
+}

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -54,7 +54,7 @@ variable "engine_version" {
 }
 
 variable "default_parameter_group_family" {
-  description = "Parameter group family for the default parameter group, according to the chosen engine and engine version. Will be omitted if `rds_custom_parameter_group_name` is provided. Defaults to mysql5.7"
+  description = "Parameter group family for the default parameter group, according to the chosen engine and engine version. Defaults to mysql5.7"
   default     = "mysql5.7"
 }
 
@@ -104,7 +104,7 @@ variable "number" {
 }
 
 variable "rds_custom_parameter_group_name" {
-  description = "A custom parameter group name to attach to the RDS instance. If not provided a default one will be created"
+  description = "A custom parameter group name to attach to the RDS instance. If not provided a default one will be used"
   default     = ""
 }
 


### PR DESCRIPTION
This PR adds the option to set a `name` for the `rds` module. This allows to customise the name of the resources when needed.