### PR TITLE
fixing sg definition for aurora

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Creates a Aurora cluster + instances, security_group, subnet_group and parameter
 * [`engine`]: String(optional) Aurora engine: `aurora`, `aurora-postgresql` or `aurora-mysql` (default: `aurora`)
 * [`engine_version`]: String(optional) Engine version to use, according to the chosen engine. You can check the available engine versions using the AWS CLI (http://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html) (default: `5.6.10a` - for MySQL)
 * [`family`]: String(optional) Parameter group family for the default parameter group, according to the chosen engine and engine version. (default: `aurora5.6` - for MySQL)
+* [`default_ports`]: Map(optional) The default ports for aurora and aurora-postgresql. (default: `3306` and `5432`)
 ### Output:
  * [`aurora_port`]: String: The port of the rds
  * [`aurora_sg_id`]: String: The security group ID

--- a/aurora/main.tf
+++ b/aurora/main.tf
@@ -67,16 +67,18 @@ resource "aws_rds_cluster" "aurora" {
 }
 
 resource "aws_rds_cluster_instance" "cluster_instances" {
-  count                   = "${var.amount_of_instances}"
-  identifier              = "${var.project}-${var.environment}${var.tag}-aurora${format("%02d", count.index + 1)}"
-  cluster_identifier      = "${aws_rds_cluster.aurora.id}"
-  instance_class          = "${var.size}"
-  db_subnet_group_name    = "${aws_db_subnet_group.aurora.id}"
-  apply_immediately       = "${var.apply_immediately}"
+  count                = "${var.amount_of_instances}"
+  identifier           = "${var.project}-${var.environment}${var.tag}-aurora${format("%02d", count.index + 1)}"
+  cluster_identifier   = "${aws_rds_cluster.aurora.id}"
+  instance_class       = "${var.size}"
+  db_subnet_group_name = "${aws_db_subnet_group.aurora.id}"
+  apply_immediately    = "${var.apply_immediately}"
+
   # To set the `db_parameter_group_name` we'll concat the instance_parameter_group_name variable with the aurora_mysql resource name as one of the two will be an empty string
   db_parameter_group_name = "${var.instance_parameter_group_name}${join("", aws_db_parameter_group.aurora_mysql.*.name)}"
   engine                  = "${var.engine}"
   engine_version          = "${var.engine_version}"
+
   tags {
     Name        = "${var.project}-${var.environment}${var.tag}-aurora${format("%02d", count.index + 1)}"
     Environment = "${var.environment}"

--- a/aurora/outputs.tf
+++ b/aurora/outputs.tf
@@ -1,5 +1,5 @@
 output "aurora_port" {
-  value = "3306"
+  value = "${local.port}"
 }
 
 output "aurora_sg_id" {

--- a/aurora/security_group.tf
+++ b/aurora/security_group.tf
@@ -2,22 +2,29 @@ data "aws_subnet" "subnet" {
   id = "${var.subnets[0]}"
 }
 
+locals {
+  port = "${var.default_ports[var.engine]}"
+}
+
 # Create RDS with Subnet and paramter group,
 resource "aws_security_group" "sg_aurora" {
   name        = "sg_aurora_${var.project}_${var.environment}${var.tag}"
   description = "Security group that is needed for the Aurora"
   vpc_id      = "${data.aws_subnet.subnet.vpc_id}"
 
-  ingress {
-    from_port       = "3306"
-    to_port         = "3306"
-    protocol        = "tcp"
-    security_groups = ["${var.security_groups}"]
-  }
-
   tags {
     Name        = "${var.project}-${var.environment}${var.tag}-sg_aurora"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }
+}
+
+resource "aws_security_group_rule" "sg_aurora_in" {
+  count                    = "${length(var.security_groups)}"
+  security_group_id        = "${aws_security_group.sg_aurora.id}"
+  type                     = "ingress"
+  from_port                = "${local.port}"
+  to_port                  = "${local.port}"
+  protocol                 = "tcp"
+  source_security_group_id = "${element(var.security_groups, count.index)}"
 }

--- a/aurora/variables.tf
+++ b/aurora/variables.tf
@@ -19,7 +19,7 @@ variable "password" {
 
 variable "rds_username" {
   description = "RDS root user"
-  default = "root"
+  default     = "root"
 }
 
 variable "backup_retention_period" {
@@ -74,14 +74,21 @@ variable "instance_parameter_group_name" {
 
 variable "engine" {
   description = "Optional parameter to set the Aurora engine "
-  default = "aurora"
+  default     = "aurora"
 }
 
 variable "engine_version" {
   description = "Optional parameter to set the Aurora engine version"
-  default = "5.6.10a"
+  default     = "5.6.10a"
 }
 
 variable "family" {
   default = "aurora5.6"
+}
+
+variable "default_ports" {
+  default = {
+    aurora            = "3306"
+    aurora-postgresql = "5432"
+  }
 }

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -40,7 +40,7 @@ variable "rds_password" {
 
 variable "rds_username" {
   description = "RDS root user"
-  default = "root"
+  default     = "root"
 }
 
 variable "engine" {


### PR DESCRIPTION
In the current rds module we've already moved to this new approach to set sg rules. This allow to add externally sg rules if needed. With the current approach setting up external rules will conflict with the existing ones and cause inconsistent behaviour 

This has been tested in terraform staging where you have to manually remove the rules in order for terraform to work properly