### PR TITLE
Add rds-replica compatibility fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Creates a RDS instance, security_group, subnet_group and parameter_group
 * [`engine`]: String(optional) RDS engine: `mysql`, `postgres` or `oracle` (default: `mysql`)
 * [`engine_version`]: String(optional) Engine version to use, according to the chosen engine. You can check the available engine versions using the AWS CLI (http://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html) (default: `5.7.17` - for MySQL)
 * [`default_parameter_group_family`]: String(optional) Parameter group family for the default parameter group, according to the chosen engine and engine version. Defaults to `mysql5.7`
-* [`replicate_source_db`]: String(optional) RDS source to replicate from
 * [`multi_az`]: bool(optional) Multi AZ for RDS master (default: true)
 * [`backup_retention_period`]: int(optional) How long do you want to keep RDS backups (default: 14)
 * [`apply_immediately`]: bool(optional) whether you want to Apply changes immediately (default: true)

--- a/rds-replica/main.tf
+++ b/rds-replica/main.tf
@@ -10,7 +10,6 @@ resource "aws_db_instance" "rds" {
   instance_class            = "${var.size}"
   vpc_security_group_ids    = ["${aws_security_group.sg_rds.id}"]
   replicate_source_db       = "${var.replicate_source_db}"
-  final_snapshot_identifier = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}" : var.name}-replica-final-${md5(timestamp())}"
   db_subnet_group_name      = "${aws_db_subnet_group.rds.id}"
   storage_encrypted         = "${var.storage_encrypted}"
 
@@ -21,6 +20,6 @@ resource "aws_db_instance" "rds" {
   }
 
   lifecycle {
-    ignore_changes = ["final_snapshot_identifier", "replicate_source_db"]
+    ignore_changes = ["replicate_source_db"]
   }
 }

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -63,7 +63,6 @@ resource "aws_db_instance" "rds" {
   db_subnet_group_name      = "${aws_db_subnet_group.rds.id}"
   parameter_group_name      = "${var.rds_custom_parameter_group_name == "" ? aws_db_parameter_group.rds.id : var.rds_custom_parameter_group_name}"
   multi_az                  = "${var.multi_az}"
-  replicate_source_db       = "${var.replicate_source_db}"
   backup_retention_period   = "${var.backup_retention_period}"
   storage_encrypted         = "${var.storage_encrypted}"
   apply_immediately         = "${var.apply_immediately}"

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -58,11 +58,6 @@ variable "default_parameter_group_family" {
   default     = "mysql5.7"
 }
 
-variable "replicate_source_db" {
-  description = "RDS source to replicate from"
-  default     = ""
-}
-
 variable "multi_az" {
   description = "Multi AZ true or false"
   default     = true


### PR DESCRIPTION
- Removes the `final_snapshot_identifier` which doesn't work when deleting an RDS replica.
- Removes the `replicate_source_db` option on the main rds module (previously untested?), since we have a separate rds-replica module for that and a couple of the main options don't work with replica's

Tested on a customer stacks, checking for changes.