### PR TITLE
adding read replica custom parameter group and monitoring_interval for RDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Creates a RDS instance, security_group, subnet_group and parameter_group
 * [`availability_zone`]: string(optional) The availability zone where you want to launch your instance in
 * [`snapshot_identifier`]: string(optional) Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05.
 * [`name`]: String(optional) Name of the resources (default to <project>-<environment><tag>-rds<number>)
+* [`monitoring_interval`]: string(optional) The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. (default to 0)
 
 ### Output:
  * [`rds_port`]: String: The port of the rds
@@ -113,6 +114,7 @@ Creates an RDS read replica instance, the replica `security_group` and a `subnet
 * [`number`]: int(optional) number of the replica (default 01)
 * [`name`]: string(optional) name of the resources (default to <project>-<environment><tag>-rds<number>-replica)
 * [`storage_encrypted`]: bool(optional) whether you want to Encrypt RDS storage (default: true)
+* [`custom_parameter_group_name`]: String(optional) A custom parameter group name to attach to the RDS instance. If not provided it will use the default from the master instance
 
 ### Output:
  * [`rds_address`]: String: The hostname of the rds instance

--- a/rds-replica/main.tf
+++ b/rds-replica/main.tf
@@ -4,6 +4,10 @@ resource "aws_db_subnet_group" "rds" {
   subnet_ids  = ["${var.subnets}"]
 }
 
+data "aws_db_instance" "master" {
+  db_instance_identifier = "${var.replicate_source_db}"
+}
+
 resource "aws_db_instance" "rds" {
   identifier                = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica" : var.name}"
   engine                    = "${var.engine}"
@@ -12,6 +16,7 @@ resource "aws_db_instance" "rds" {
   replicate_source_db       = "${var.replicate_source_db}"
   db_subnet_group_name      = "${aws_db_subnet_group.rds.id}"
   storage_encrypted         = "${var.storage_encrypted}"
+  parameter_group_name      = "${var.custom_parameter_group_name == "" ? data.aws_db_instance.master.db_parameter_groups[0] : var.custom_parameter_group_name}"
 
   tags {
     Name        = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}-replica" : var.name}"

--- a/rds-replica/variables.tf
+++ b/rds-replica/variables.tf
@@ -60,3 +60,8 @@ variable "storage_encrypted" {
   description = "Encrypt RDS storage"
   default     = true
 }
+
+variable "custom_parameter_group_name" {
+  description = "A custom parameter group name to attach to the RDS instance. If not provided it will use the default from the master instance"
+  default = ""
+}

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -70,6 +70,7 @@ resource "aws_db_instance" "rds" {
   final_snapshot_identifier = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}" : var.name}-final-${md5(timestamp())}"
   availability_zone         = "${var.availability_zone}"
   snapshot_identifier       = "${var.snapshot_identifier}"
+  monitoring_interval       = "${var.monitoring_interval}"
 
   tags {
     Name        = "${length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds${var.number}" : var.name}"

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -122,3 +122,8 @@ variable "name" {
   description = "The name of the RDS instance"
   default = ""
 }
+
+variable "monitoring_interval" {
+  description = "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. Valid Values: 0, 1, 5, 10, 15, 30, 60."
+  default = "0"
+}


### PR DESCRIPTION
This PR adds the option to specify a custom parameter group for the read replica instance and to change the monitoring interval to a different value as per documentation.
This is part of the following issues:
https://github.com/teamleadercrm/skyscrapers/issues/211
https://github.com/teamleadercrm/skyscrapers/issues/212

This PR has been tested with a plan of the module in the two scenarios