### PR TITLE
Add a create_before_destroy lifecycle rule to some resources

### DIFF
--- a/aurora/main.tf
+++ b/aurora/main.tf
@@ -37,6 +37,10 @@ resource "aws_db_parameter_group" "aurora_mysql" {
 
     value = "FILE"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_rds_cluster" "aurora" {

--- a/aurora/security_group.tf
+++ b/aurora/security_group.tf
@@ -17,6 +17,10 @@ resource "aws_security_group" "sg_aurora" {
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "sg_aurora_in" {

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -43,6 +43,10 @@ resource "aws_db_parameter_group" "rds" {
   family      = "${var.default_parameter_group_family}"
   description = "RDS ${var.project} ${var.environment} parameter group for ${var.engine}"
   parameter   = "${local.default_db_parameters[var.engine]}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_db_instance" "rds" {

--- a/rds/security_group.tf
+++ b/rds/security_group.tf
@@ -9,6 +9,10 @@ resource "aws_security_group" "sg_rds" {
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "rds_sg_in" {


### PR DESCRIPTION
When changing names, the new security group and parameter group should be created before destroying the old ones.
Otherwise terraform times out trying to delete the old security group first.