### PR TITLE
removes default value for security group count

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Creates a RDS instance, security_group, subnet_group and parameter_group
 | rds\_custom\_parameter\_group\_name | A custom parameter group name to attach to the RDS instance. If not provided a default one will be used | string | `""` | no |
 | rds\_password | RDS root password | string | n/a | yes |
 | rds\_username | RDS root user | string | `"root"` | no |
-| security\_groups | Security groups that are allowed to access the RDS | list | `<list>` | no |
-| security\_groups\_count | Number of security groups provided in `security_groups` variable | string | `"0"` | no |
+| security\_groups | Security groups that are allowed to access the RDS | list | `<list>` | yes |
+| security\_groups\_count | Number of security groups provided in `security_groups` variable | string | n/a | yes |
 | size | Instance size | string | `"db.t2.small"` | no |
 | skip\_final\_snapshot | Skip final snapshot when destroying RDS | string | `"false"` | no |
 | snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `""` | no |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Creates a RDS instance, security_group, subnet_group and parameter_group
 | rds\_custom\_parameter\_group\_name | A custom parameter group name to attach to the RDS instance. If not provided a default one will be used | string | `""` | no |
 | rds\_password | RDS root password | string | n/a | yes |
 | rds\_username | RDS root user | string | `"root"` | no |
-| security\_groups | Security groups that are allowed to access the RDS | list | `<list>` | yes |
+| security\_groups | Security groups that are allowed to access the RDS | list | n/a | yes |
 | security\_groups\_count | Number of security groups provided in `security_groups` variable | string | n/a | yes |
 | size | Instance size | string | `"db.t2.small"` | no |
 | skip\_final\_snapshot | Skip final snapshot when destroying RDS | string | `"false"` | no |

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -10,7 +10,6 @@ variable "security_groups" {
 
 variable "security_groups_count" {
   description = "Number of security groups provided in `security_groups` variable"
-  default     = 0
 }
 
 variable "allowed_cidr_blocks" {

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -5,7 +5,6 @@ variable "vpc_id" {
 variable "security_groups" {
   description = "Security groups that are allowed to access the RDS"
   type        = "list"
-  default     = []
 }
 
 variable "security_groups_count" {


### PR DESCRIPTION
As mentioned in the PR that introduced this variable, the current approach is too dangerous and can cause serious problems when migrating to this module. Removing a default value forces the user to set the correct value.