### PR TITLE
Add ability to set storage and max_allocated_storage on rds slave

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Creates an RDS read replica instance, the replica `security_group` and a `subnet
 | storage\_encrypted | Encrypt RDS storage | string | `"true"` | no |
 | tag | A tag used to identify an RDS in a project that has more than one RDS | string | `""` | no |
 | max\_allocated\_storage | When configured, the upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Configuring this will automatically ignore differences to allocated\_storage. Must be greater than or equal to allocated\_storage or 0 to disable Storage Autoscaling. | string | `"0"` | no |
-| storage | How many GBs of space does your database need? | string | `"10"` | no |
+| allocated_storage | How many GBs of space does your database need? | string | `"10"` | no |
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ Creates an RDS read replica instance, the replica `security_group` and a `subnet
 | size | Instance size | string | `"db.t2.small"` | no |
 | storage\_encrypted | Encrypt RDS storage | string | `"true"` | no |
 | tag | A tag used to identify an RDS in a project that has more than one RDS | string | `""` | no |
-| max\_allocated\_storage | When configured, the upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Configuring this will automatically ignore differences to allocated\_storage. Must be greater than or equal to allocated\_storage or 0 to disable Storage Autoscaling. | string | `"0"` | no |
-| allocated_storage | How many GBs of space does your database need? | string | `"10"` | no |
+| max\_allocated\_storage | When configured, the upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Configuring this will automatically ignore differences to allocated\_storage. Must be greater than or equal to allocated\_storage or 0 to disable Storage Autoscaling. If not set the default of the master instance is set. | string | `null` | no |
+| allocated_storage | How many GBs of space does your database need? If not set the default of the master instance is set. | string | `null` | no |
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Creates an RDS read replica instance, the replica `security_group` and a `subnet
 | size | Instance size | string | `"db.t2.small"` | no |
 | storage\_encrypted | Encrypt RDS storage | string | `"true"` | no |
 | tag | A tag used to identify an RDS in a project that has more than one RDS | string | `""` | no |
+| max\_allocated\_storage | When configured, the upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Configuring this will automatically ignore differences to allocated\_storage. Must be greater than or equal to allocated\_storage or 0 to disable Storage Autoscaling. | string | `"0"` | no |
+| storage | How many GBs of space does your database need? | string | `"10"` | no |
 
 ### Outputs
 

--- a/rds-replica/main.tf
+++ b/rds-replica/main.tf
@@ -18,8 +18,8 @@ resource "aws_db_instance" "rds" {
   replicate_source_db             = var.replicate_source_db
   db_subnet_group_name            = aws_db_subnet_group.rds[0].id
   storage_encrypted               = var.storage_encrypted
-  allocated_storage               = var.allocated_storage
-  max_allocated_storage           = var.max_allocated_storage
+  allocated_storage               = var.allocated_storage ? data.aws_db_instance.master.rds_allocated_storage : var.allocated_storage
+  max_allocated_storage           = var.max_allocated_storage ? data.aws_db_instance.master.rds_allocated_storage : var.max_allocated_storage
   parameter_group_name            = var.custom_parameter_group_name == "" ? data.aws_db_instance.master.db_parameter_groups[0] : var.custom_parameter_group_name
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
   backup_retention_period         = var.backup_retention_period

--- a/rds-replica/main.tf
+++ b/rds-replica/main.tf
@@ -18,8 +18,8 @@ resource "aws_db_instance" "rds" {
   replicate_source_db             = var.replicate_source_db
   db_subnet_group_name            = aws_db_subnet_group.rds[0].id
   storage_encrypted               = var.storage_encrypted
-  allocated_storage               = var.allocated_storage ? data.aws_db_instance.master.rds_allocated_storage : var.allocated_storage
-  max_allocated_storage           = var.max_allocated_storage ? data.aws_db_instance.master.rds_allocated_storage : var.max_allocated_storage
+  allocated_storage               = var.allocated_storage
+  max_allocated_storage           = var.max_allocated_storage
   parameter_group_name            = var.custom_parameter_group_name == "" ? data.aws_db_instance.master.db_parameter_groups[0] : var.custom_parameter_group_name
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
   backup_retention_period         = var.backup_retention_period

--- a/rds-replica/main.tf
+++ b/rds-replica/main.tf
@@ -18,6 +18,8 @@ resource "aws_db_instance" "rds" {
   replicate_source_db             = var.replicate_source_db
   db_subnet_group_name            = aws_db_subnet_group.rds[0].id
   storage_encrypted               = var.storage_encrypted
+  allocated_storage               = var.allocated_storage
+  max_allocated_storage           = var.max_allocated_storage
   parameter_group_name            = var.custom_parameter_group_name == "" ? data.aws_db_instance.master.db_parameter_groups[0] : var.custom_parameter_group_name
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
   backup_retention_period         = var.backup_retention_period

--- a/rds-replica/variables.tf
+++ b/rds-replica/variables.tf
@@ -62,6 +62,17 @@ variable "storage_encrypted" {
   default     = true
 }
 
+variable "storage" {
+  description = "How many GBs of space does your database need?"
+  default     = "10"
+}
+
+variable "max_allocated_storage" {
+  description = "When configured, the upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Configuring this will automatically ignore differences to allocated_storage. Must be greater than or equal to allocated_storage or 0 to disable Storage Autoscaling."
+  type        = string
+  default     = "0"
+}
+
 variable "custom_parameter_group_name" {
   description = "A custom parameter group name to attach to the RDS instance. If not provided it will use the default from the master instance"
   default     = ""

--- a/rds-replica/variables.tf
+++ b/rds-replica/variables.tf
@@ -62,15 +62,14 @@ variable "storage_encrypted" {
   default     = true
 }
 
-variable "storage" {
+variable "allocated_storage" {
   description = "How many GBs of space does your database need?"
-  default     = "10"
+  default     = null
 }
 
 variable "max_allocated_storage" {
   description = "When configured, the upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Configuring this will automatically ignore differences to allocated_storage. Must be greater than or equal to allocated_storage or 0 to disable Storage Autoscaling."
-  type        = string
-  default     = "0"
+  default     = null
 }
 
 variable "custom_parameter_group_name" {

--- a/rds/outputs.tf
+++ b/rds/outputs.tf
@@ -27,8 +27,3 @@ output "aws_db_subnet_group_id" {
   description = "The subnet group id of the RDS instance"
   value       = aws_db_subnet_group.rds.id
 }
-
-output "rds_allocated_storage" {
-  description = "The allocated storage of the RDS instance"
-  value       = aws_db_instance.rds.allocated_storage
-}

--- a/rds/outputs.tf
+++ b/rds/outputs.tf
@@ -28,3 +28,7 @@ output "aws_db_subnet_group_id" {
   value       = aws_db_subnet_group.rds.id
 }
 
+output "rds_allocated_storage" {
+  description = "The allocated storage of the RDS instance"
+  value       = aws_db_instance.rds.allocated_storage
+}

--- a/rds/outputs.tf
+++ b/rds/outputs.tf
@@ -27,3 +27,4 @@ output "aws_db_subnet_group_id" {
   description = "The subnet group id of the RDS instance"
   value       = aws_db_subnet_group.rds.id
 }
+


### PR DESCRIPTION
We are running different disk sizes on our slaves since we have set a large binlog retention time on one of them we need the difference. 
This adds the ability to configure those.