### PR TITLE
Add skip final snapshot

### DIFF
--- a/rds-replica/main.tf
+++ b/rds-replica/main.tf
@@ -26,6 +26,7 @@ resource "aws_db_instance" "rds" {
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
   backup_retention_period         = var.backup_retention_period
   auto_minor_version_upgrade      = var.auto_minor_version_upgrade
+  skip_final_snapshot             = true
 
   tags = {
     Name        = length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds${count.index + 1}-replica" : var.name


### PR DESCRIPTION
According to AWS, `Final Snapshots are not available for Read Replica DB Instances.` and TF fails to destroy an instance when it's created without the skip final snapshot no matter what.
Note that due to [this bug](https://github.com/hashicorp/terraform-provider-aws/issues/2588) this change won't effect current instances created by the module, but only newly created one with the skip final snapshot set to true 