### PR TITLE
Update replicator for Aurora

### DIFF
--- a/snapshot-cross-account-replicator/functions/lambda.py
+++ b/snapshot-cross-account-replicator/functions/lambda.py
@@ -338,4 +338,6 @@ def delete_intermediate_snapshot(event, context):
     else:
         snapshot = match_snapshot_event(rds, event)
         if snapshot:
+            snapshot_set_replicating_tag(
+                rds, snapshot['DBSnapshotArn'], 'finished')
             delete_snapshot(source_rds, snapshot['DBSnapshotIdentifier'])

--- a/snapshot-cross-account-replicator/functions/lambda.py
+++ b/snapshot-cross-account-replicator/functions/lambda.py
@@ -258,7 +258,7 @@ def replicate_snapshot(event, context):
 
     # CRON based, search & replicate all matching snapshots
     # Needed for the cross-account replication in cluster mode (step 3), because AWS
-    # doesn't public a cluster finished snapshot event
+    # doesn't publish a cluster finished snapshot event
     if is_cluster and replication_type == 'cross-account':
         snapshots = match_cluster_snapshots(rds)
         for snapshot in snapshots:

--- a/snapshot-cross-account-replicator/functions/lambda.py
+++ b/snapshot-cross-account-replicator/functions/lambda.py
@@ -330,6 +330,8 @@ def delete_intermediate_snapshot(event, context):
     if is_cluster:
         snapshots = match_cluster_snapshots(rds)
         for snapshot in snapshots:
+            snapshot_set_replicating_tag(
+                rds, snapshot['DBClusterSnapshotArn'], 'finished')
             delete_snapshot(
                 source_rds, snapshot['DBClusterSnapshotIdentifier'])
     # EVENT based, used for step 4 (instance)

--- a/snapshot-cross-account-replicator/functions/lambda.py
+++ b/snapshot-cross-account-replicator/functions/lambda.py
@@ -13,17 +13,24 @@ setup_name = os.environ['SETUP_NAME']
 replication_type = os.environ['TYPE']
 source_region = os.environ['SOURCE_REGION']
 retention_period = os.environ['RETENTION_PERIOD']
-
+is_cluster = os.environ['IS_CLUSTER']
 
 def share_snapshot(rds, snapshot):
     """Enables the sharing of a snapshot to the target replication AWS account"""
 
     try:
-        rds.modify_db_snapshot_attribute(
-            DBSnapshotIdentifier=snapshot['DBSnapshotIdentifier'],
-            AttributeName='restore',
-            ValuesToAdd=[target_account_id]
-        )
+        if is_cluster:
+            rds.modify_db_cluster_snapshot_attribute(
+                DBClusterSnapshotIdentifier=snapshot['DBClusterSnapshotIdentifier'],
+                AttributeName='restore',
+                ValuesToAdd=[target_account_id]
+            )
+        else:
+            rds.modify_db_snapshot_attribute(
+                DBSnapshotIdentifier=snapshot['DBSnapshotIdentifier'],
+                AttributeName='restore',
+                ValuesToAdd=[target_account_id]
+            )
     except botocore.exceptions.ClientError as e:
         raise Exception("Could not share snapshot with target account: %s" % e)
 
@@ -56,18 +63,32 @@ def copy_snapshot(snapshot, rds, source_region):
     """Triggers a local copy of a snapshot using the provided RDS client"""
 
     try:
-        rds.copy_db_snapshot(
-            SourceDBSnapshotIdentifier=snapshot['DBSnapshotArn'],
-            TargetDBSnapshotIdentifier=snapshot['DBSnapshotIdentifier'],
-            KmsKeyId=target_account_kms_key_arn,
-            SourceRegion=source_region,
-            Tags=[
-                {
-                    'Key': 'created_by',
-                    'Value': setup_name
-                }
-            ]
-        )
+        if is_cluster:
+            rds.copy_db_cluster_snapshot(
+                SourceDBClusterSnapshotIdentifier=snapshot['DBClusterSnapshotArn'],
+                TargetDBClusterSnapshotIdentifier=snapshot['DBClusterSnapshotIdentifier'],
+                KmsKeyId=target_account_kms_key_arn,
+                SourceRegion=source_region,
+                Tags=[
+                    {
+                        'Key': 'created_by',
+                        'Value': setup_name
+                    }
+                ]
+            )
+        else:
+            rds.copy_db_snapshot(
+                SourceDBSnapshotIdentifier=snapshot['DBSnapshotArn'],
+                TargetDBSnapshotIdentifier=snapshot['DBSnapshotIdentifier'],
+                KmsKeyId=target_account_kms_key_arn,
+                SourceRegion=source_region,
+                Tags=[
+                    {
+                        'Key': 'created_by',
+                        'Value': setup_name
+                    }
+                ]
+            )
     except botocore.exceptions.ClientError as e:
         raise Exception("Could not issue copy command: %s" % e)
 
@@ -86,8 +107,12 @@ def delete_snapshot(rds, snapshot_id):
 
     print(("Deleting snapshot id:", snapshot_id))
     try:
-        rds.delete_db_snapshot(
-            DBSnapshotIdentifier=snapshot_id)
+        if is_cluster:
+            rds.delete_db_cluster_snapshot(
+                DBClusterSnapshotIdentifier=snapshot_id)
+        else:
+            rds.delete_db_snapshot(
+                DBSnapshotIdentifier=snapshot_id)
     except botocore.exceptions.ClientError as e:
         raise Exception("Could not issue delete command: %s" % e)
 
@@ -96,9 +121,13 @@ def match_snapshot_event(rds, event):
     """Checks if the provided event is meant for this lambda"""
 
     snapshot_id = event['detail']['SourceIdentifier']
-    snapshot = rds.describe_db_snapshots(
-        DBSnapshotIdentifier=snapshot_id)['DBSnapshots'][0]
-    if snapshot['DBInstanceIdentifier'] in instances.split(',') and match_tags(snapshot) and snapshot['Status'] == 'available':
+    if is_cluster:
+        snapshot = rds.describe_db_cluster_snapshots(
+            DBClusterSnapshotIdentifier=snapshot_id)['DBClusterSnapshots'][0]
+    else:
+        snapshot = rds.describe_db_snapshots(
+            DBSnapshotIdentifier=snapshot_id)['DBSnapshots'][0]
+    if snapshot['DBClusterIdentifier'] or snapshot['DBInstanceIdentifier'] in instances.split(',') and match_tags(snapshot) and snapshot['Status'] == 'available':
         return snapshot
     else:
         return False
@@ -113,15 +142,29 @@ def cleanup_snapshots(event, context):
     rds = boto3.client('rds')
 
     for instance in instances.split(','):
-        paginator = rds.get_paginator('describe_db_snapshots')
-        page_iterator = paginator.paginate(
-            DBInstanceIdentifier=instance, SnapshotType='manual')
+        if is_cluster:
+            paginator = rds.get_paginator('describe_db_cluster_snapshots')
+            page_iterator = paginator.paginate(
+                DBClusterIdentifier=instance, SnapshotType='manual')
 
-        for page in page_iterator:
-            for snapshot in page['DBSnapshots']:
-                create_ts = snapshot['SnapshotCreateTime'].replace(tzinfo=None)
-                if create_ts < datetime.datetime.now() - datetime.timedelta(days=int(retention_period)) and match_tags(snapshot):
-                    delete_snapshot(rds, snapshot['DBSnapshotIdentifier'])
+            for page in page_iterator:
+                for snapshot in page['DBClusterSnapshots']:
+                    create_ts = snapshot['SnapshotCreateTime'].replace(
+                        tzinfo=None)
+                    if create_ts < datetime.datetime.now() - datetime.timedelta(days=int(retention_period)) and match_tags(snapshot):
+                        delete_snapshot(
+                            rds, snapshot['DBClusterSnapshotIdentifier'])
+        else:
+            paginator = rds.get_paginator('describe_db_snapshots')
+            page_iterator = paginator.paginate(
+                DBInstanceIdentifier=instance, SnapshotType='manual')
+
+            for page in page_iterator:
+                for snapshot in page['DBSnapshots']:
+                    create_ts = snapshot['SnapshotCreateTime'].replace(
+                        tzinfo=None)
+                    if create_ts < datetime.datetime.now() - datetime.timedelta(days=int(retention_period)) and match_tags(snapshot):
+                        delete_snapshot(rds, snapshot['DBSnapshotIdentifier'])
 
 
 def replicate_snapshot(event, context):
@@ -131,20 +174,32 @@ def replicate_snapshot(event, context):
     snapshot = match_snapshot_event(rds, event)
     if snapshot:
         if replication_type == 'cross-region':
-            print('Replicating snapshot ' +
-                  snapshot['DBSnapshotIdentifier'] + ' to region ' + target_region)
+            if is_cluster:
+                print('Replicating snapshot ' +
+                      snapshot['DBClusterSnapshotIdentifier'] + ' to region ' + target_region)
+            else:
+                print('Replicating snapshot ' +
+                      snapshot['DBSnapshotIdentifier'] + ' to region ' + target_region)
             target_region_rds = boto3.client('rds', region_name=target_region)
             copy_snapshot(snapshot, target_region_rds, source_region)
         elif replication_type == 'cross-account':
-            print('Replicating snapshot ' +
-                  snapshot['DBSnapshotIdentifier'] + ' to AWS account ' + target_account_id)
+            if is_cluster:
+                print('Replicating snapshot ' +
+                      snapshot['DBClusterSnapshotIdentifier'] + ' to AWS account ' + target_account_id)
+            else:
+                print('Replicating snapshot ' +
+                      snapshot['DBSnapshotIdentifier'] + ' to AWS account ' + target_account_id)
             share_snapshot(rds, snapshot)
             target_account_rds = get_assumed_role_rds_client(
                 target_account_iam_role_arn, target_region)
             copy_snapshot(snapshot, target_account_rds, target_region)
             source_region_rds = boto3.client('rds', region_name=source_region)
-            delete_snapshot(source_region_rds,
-                            snapshot['DBSnapshotIdentifier'])
+            if is_cluster:
+                delete_snapshot(source_region_rds,
+                                snapshot['DBSnapshotIdentifier'])
+            else:
+                delete_snapshot(source_region_rds,
+                                snapshot['DBClusterSnapshotIdentifier'])
 
 
 def create_snapshots(event, context):
@@ -158,15 +213,26 @@ def create_snapshots(event, context):
         now = datetime.datetime.now()
         db_snapshot_name = instance + '-' + now.strftime('%Y-%m-%d-%H-%M')
         try:
-            source_rds.create_db_snapshot(
-                DBSnapshotIdentifier=db_snapshot_name,
-                DBInstanceIdentifier=instance,
-                Tags=[
-                    {
-                        'Key': 'created_by',
-                        'Value': setup_name
-                    }
-                ])
+            if is_cluster:
+                source_rds.create_db_cluster_snapshot(
+                    DBClusterSnapshotIdentifier=db_snapshot_name,
+                    DBClusterIdentifier=instance,
+                    Tags=[
+                        {
+                            'Key': 'created_by',
+                            'Value': setup_name
+                        }
+                    ])
+            else:
+                source_rds.create_db_snapshot(
+                    DBSnapshotIdentifier=db_snapshot_name,
+                    DBInstanceIdentifier=instance,
+                    Tags=[
+                        {
+                            'Key': 'created_by',
+                            'Value': setup_name
+                        }
+                    ])
         except botocore.exceptions.ClientError as e:
             raise Exception("Could not issue create command: %s" % e)
 
@@ -179,4 +245,8 @@ def delete_intermediate_snapshot(event, context):
     if snapshot:
         source_rds = get_assumed_role_rds_client(
             source_account_iam_role_arn, target_region)
-        delete_snapshot(source_rds, snapshot['DBSnapshotIdentifier'])
+        if is_cluster:
+            delete_snapshot(
+                source_rds, snapshot['DBClusterSnapshotIdentifier'])
+        else:
+            delete_snapshot(source_rds, snapshot['DBSnapshotIdentifier'])

--- a/snapshot-cross-account-replicator/functions/lambda.py
+++ b/snapshot-cross-account-replicator/functions/lambda.py
@@ -15,6 +15,7 @@ source_region = os.environ['SOURCE_REGION']
 retention_period = os.environ['RETENTION_PERIOD']
 is_cluster = os.environ['IS_CLUSTER']
 
+
 def share_snapshot(rds, snapshot):
     """Enables the sharing of a snapshot to the target replication AWS account"""
 
@@ -62,6 +63,17 @@ def get_assumed_role_rds_client(iam_role_arn, region):
 def copy_snapshot(snapshot, rds, source_region):
     """Triggers a local copy of a snapshot using the provided RDS client"""
 
+    tags = [
+        {
+            'Key': 'created_by',
+            'Value': setup_name
+        },
+        {
+            'Key': 'replicating',
+            'Value': 'false'
+        }
+    ]
+
     try:
         if is_cluster:
             rds.copy_db_cluster_snapshot(
@@ -69,16 +81,7 @@ def copy_snapshot(snapshot, rds, source_region):
                 TargetDBClusterSnapshotIdentifier=snapshot['DBClusterSnapshotIdentifier'],
                 KmsKeyId=target_account_kms_key_arn,
                 SourceRegion=source_region,
-                Tags=[
-                    {
-                        'Key': 'created_by',
-                        'Value': setup_name
-                    },
-                    {
-                        'Key': 'replicating',
-                        'Value': 'false'
-                    }
-                ]
+                Tags=tags
             )
         else:
             rds.copy_db_snapshot(
@@ -86,28 +89,52 @@ def copy_snapshot(snapshot, rds, source_region):
                 TargetDBSnapshotIdentifier=snapshot['DBSnapshotIdentifier'],
                 KmsKeyId=target_account_kms_key_arn,
                 SourceRegion=source_region,
-                Tags=[
-                    {
-                        'Key': 'created_by',
-                        'Value': setup_name
-                    },
-                    {
-                        'Key': 'replicating',
-                        'Value': 'false'
-                    }
-                ]
+                Tags=tags
             )
     except botocore.exceptions.ClientError as e:
         raise Exception("Could not issue copy command: %s" % e)
 
 
-def match_tags(snapshot):
-    """Checks if the snapshot was created by the current setup"""
+def match_tags(snapshot, replication_status='false'):
+    """Checks if the snapshot is meant for this lambda"""
 
-    for tags in snapshot['TagList']:
-        if tags['Key'] == 'created_by' and tags['Value'] == setup_name:
-            return True
+    tags = snapshot['TagList']
+
+    try:
+        for tag1 in tags:
+            if tag1['Key'] == 'created_by' and tag1['Value'] == setup_name:
+                for tag2 in tags:
+                    if tag2['Key'].lower() == 'replicating' and tag2['Value'].lower() == replication_status:
+                        return True
+    except Exception:
+        return False
+
     return False
+
+
+def snapshot_set_replicating_tag(rds, snapshot_arn, value):
+    """Sets replicating=true Tag on snapshot"""
+
+    rds.add_tags_to_resource(
+        ResourceName=snapshot_arn,
+        Tags=[
+            {
+                'Key': 'replicating',
+                'Value': value
+            }
+        ]
+    )
+
+
+def delete_old_snapshot(rds, snapshot):
+    """Removes snapshots alder than retention_period"""
+
+    create_ts = snapshot['SnapshotCreateTime'].replace(tzinfo=None)
+    if create_ts < datetime.datetime.now() - datetime.timedelta(days=int(retention_period)) and match_tags(snapshot):
+        if is_cluster:
+            delete_snapshot(rds, snapshot['DBSnapshotIdentifier'])
+        else:
+            delete_snapshot(rds, snapshot['DBClusterSnapshotIdentifier'])
 
 
 def delete_snapshot(rds, snapshot_id):
@@ -125,20 +152,6 @@ def delete_snapshot(rds, snapshot_id):
         raise Exception("Could not issue delete command: %s" % e)
 
 
-def match_snapshot_tags(tags, replication_status):
-    """Checks if the snapshot with provided tags is meant for this lambda"""
-
-    try:
-        for tag1 in tags:
-            if tag1['Key'].lower() == 'created_by' and tag1['Value'].lower() == setup_name.lower():
-                for tag2 in tags:
-                    if tag2['Key'].lower() == 'replicating' and tag2['Value'].lower() == replication_status:
-                        return True
-    except Exception:
-        return False
-
-    return False
-
 def match_snapshot_event(rds, event):
     """Checks if the provided event is meant for this lambda"""
 
@@ -146,31 +159,40 @@ def match_snapshot_event(rds, event):
     if is_cluster:
         snapshot = rds.describe_db_cluster_snapshots(
             DBClusterSnapshotIdentifier=snapshot_id)['DBClusterSnapshots'][0]
-        if snapshot['DBClusterIdentifier'] in instances.split(',') and match_tags(snapshot) and snapshot['Status'] == 'available':
+        if snapshot['DBClusterIdentifier'] in instances.split(',') and match_tags(snapshot) and snapshot['Status'].lower() == 'available':
             return snapshot
         else:
             return False
     else:
         snapshot = rds.describe_db_snapshots(
             DBSnapshotIdentifier=snapshot_id)['DBSnapshots'][0]
-        if snapshot['DBInstanceIdentifier'] in instances.split(',') and match_tags(snapshot) and snapshot['Status'] == 'available':
+        if snapshot['DBInstanceIdentifier'] in instances.split(',') and match_tags(snapshot) and snapshot['Status'].lower() == 'available':
             return snapshot
         else:
             return False
 
 
-def snapshot_set_replicating_tag(rds, snapshot_arn, value):
-    """Sets replicating=true Tag on snapshot"""
+def match_cluster_snapshots(rds):
+    """Returns all matching cluster snapshots to replicate or delete"""
 
-    rds.add_tags_to_resource(
-        ResourceName=snapshot_arn,
-        Tags=[
-            {
-                'Key': 'replicating',
-                'Value': value
-            }
-        ]
+    snapshots = []
+
+    paginator = rds.get_paginator('describe_db_cluster_snapshots')
+    page_iterator = paginator.paginate(
+        SnapshotType='manual',
+        IncludeShared=False,
+        IncludePublic=False
     )
+
+    for page in page_iterator:
+        for snapshot in page['DBClusterSnapshots']:
+            snapshot_taglist = rds.list_tags_for_resource(
+                ResourceName=snapshot['DBClusterSnapshotArn'])
+
+            if snapshot['Status'].lower() == 'available' and match_tags(snapshot_taglist):
+                snapshots.append(snapshot)
+
+    return snapshots
 
 
 def cleanup_snapshots(event, context):
@@ -189,11 +211,7 @@ def cleanup_snapshots(event, context):
 
             for page in page_iterator:
                 for snapshot in page['DBClusterSnapshots']:
-                    create_ts = snapshot['SnapshotCreateTime'].replace(
-                        tzinfo=None)
-                    if create_ts < datetime.datetime.now() - datetime.timedelta(days=int(retention_period)) and match_tags(snapshot):
-                        delete_snapshot(
-                            rds, snapshot['DBClusterSnapshotIdentifier'])
+                    delete_old_snapshot(rds, snapshot)
         else:
             paginator = rds.get_paginator('describe_db_snapshots')
             page_iterator = paginator.paginate(
@@ -201,14 +219,39 @@ def cleanup_snapshots(event, context):
 
             for page in page_iterator:
                 for snapshot in page['DBSnapshots']:
-                    create_ts = snapshot['SnapshotCreateTime'].replace(
-                        tzinfo=None)
-                    if create_ts < datetime.datetime.now() - datetime.timedelta(days=int(retention_period)) and match_tags(snapshot):
-                        delete_snapshot(rds, snapshot['DBSnapshotIdentifier'])
+                    delete_old_snapshot(rds, snapshot)
+
+
+def replicate_snapshot_cross_account(rds, snapshot):
+    """Replicates (share&copy) a snapshot across accounts"""
+
+    if is_cluster:
+        snapshot_set_replicating_tag(
+            rds, snapshot['DBClusterSnapshotArn'], 'true')
+        print('Replicating snapshot ' +
+              snapshot['DBClusterSnapshotIdentifier'] + ' to AWS account ' + target_account_id)
+    else:
+        snapshot_set_replicating_tag(
+            rds, snapshot['DBSnapshotArn'], 'true')
+        print('Replicating snapshot ' +
+              snapshot['DBSnapshotIdentifier'] + ' to AWS account ' + target_account_id)
+
+    share_snapshot(rds, snapshot)
+    target_account_rds = get_assumed_role_rds_client(
+        target_account_iam_role_arn, target_region)
+    copy_snapshot(snapshot, target_account_rds, target_region)
+    source_region_rds = boto3.client('rds', region_name=source_region)
+
+    # Delete initial snapshot in source account, source region
+    if is_cluster:
+        delete_snapshot(source_region_rds,
+                        snapshot['DBClusterSnapshotIdentifier'])
+    else:
+        delete_snapshot(source_region_rds, snapshot['DBSnapshotIdentifier'])
 
 
 def replicate_snapshot(event, context):
-    """Lambda entry point for the cross-region and cross-account replication"""
+    """Lambda entry point for the cross-region and cross-account replication (STEP2&3)"""
     # This gets run in step 2 (cross-region) and step 3 (cross-account)
 
     rds = boto3.client('rds')
@@ -217,34 +260,9 @@ def replicate_snapshot(event, context):
     # Needed for the cross-account replication in cluster mode (step 3), because AWS
     # doesn't public a cluster finished snapshot event
     if is_cluster and replication_type == 'cross-account':
-        paginator = rds.get_paginator('describe_db_cluster_snapshots')
-        page_iterator = paginator.paginate(
-            SnapshotType='manual',
-            IncludeShared=False,
-            IncludePublic=False
-        )
-
-        for page in page_iterator:
-            for snapshot in page['DBClusterSnapshots']:
-                snapshot_taglist = rds.list_tags_for_resource(
-                    ResourceName=snapshot['DBClusterSnapshotArn'])
-
-                if snapshot['Status'].lower() == 'available' and match_snapshot_tags(snapshot_taglist['TagList'], "false"):
-                    snapshot_set_replicating_tag(
-                        rds, snapshot['DBClusterSnapshotArn'], 'true')
-                    print('Replicating snapshot ' +
-                          snapshot['DBClusterSnapshotIdentifier'] + ' to AWS account ' + target_account_id)
-                    share_snapshot(rds, snapshot)
-                    target_account_rds = get_assumed_role_rds_client(
-                        target_account_iam_role_arn, target_region)
-                    copy_snapshot(
-                        snapshot, target_account_rds, target_region)
-                    source_region_rds = boto3.client(
-                        'rds', region_name=source_region)
-                    # Delete initial snapshot in source account, source region
-                    delete_snapshot(source_region_rds,
-                                    snapshot['DBClusterSnapshotIdentifier'])
-
+        snapshots = match_cluster_snapshots(rds)
+        for snapshot in snapshots:
+            replicate_snapshot_cross_account(rds, snapshot)
     # EVENT based, used for step 2 (instance and cluster) and step 3 (instance)
     else:
         snapshot = match_snapshot_event(rds, event)
@@ -260,27 +278,26 @@ def replicate_snapshot(event, context):
                     'rds', region_name=target_region)
                 copy_snapshot(snapshot, target_region_rds, source_region)
             elif replication_type == 'cross-account':
-                snapshot_set_replicating_tag(
-                    rds, snapshot['DBSnapshotArn'], 'true')
-                print('Replicating snapshot ' +
-                      snapshot['DBSnapshotIdentifier'] + ' to AWS account ' + target_account_id)
-                share_snapshot(rds, snapshot)
-                target_account_rds = get_assumed_role_rds_client(
-                    target_account_iam_role_arn, target_region)
-                copy_snapshot(snapshot, target_account_rds, target_region)
-                source_region_rds = boto3.client(
-                    'rds', region_name=source_region)
-                # Delete initial snapshot in source account, source region
-                delete_snapshot(source_region_rds,
-                                snapshot['DBSnapshotIdentifier'])
+                replicate_snapshot_cross_account(rds, snapshot)
 
 
 def create_snapshots(event, context):
-    """Lambda entry point for the snapshot creation"""
+    """Lambda entry point for the snapshot creation (STEP1)"""
 
     print('Lambda function start: going to create snapshots for the RDS instances ' + instances)
 
     source_rds = boto3.client('rds', region_name=source_region)
+
+    tags = [
+        {
+            'Key': 'created_by',
+            'Value': setup_name
+        },
+        {
+            'Key': 'replicating',
+            'Value': 'false'
+        }
+    ]
 
     for instance in instances.split(','):
         now = datetime.datetime.now()
@@ -290,36 +307,33 @@ def create_snapshots(event, context):
                 source_rds.create_db_cluster_snapshot(
                     DBClusterSnapshotIdentifier=db_snapshot_name,
                     DBClusterIdentifier=instance,
-                    Tags=[
-                        {
-                            'Key': 'created_by',
-                            'Value': setup_name
-                        },
-                    ])
+                    Tags=tags
+                )
             else:
                 source_rds.create_db_snapshot(
                     DBSnapshotIdentifier=db_snapshot_name,
                     DBInstanceIdentifier=instance,
-                    Tags=[
-                        {
-                            'Key': 'created_by',
-                            'Value': setup_name
-                        }
-                    ])
+                    Tags=tags
+                )
         except botocore.exceptions.ClientError as e:
             raise Exception("Could not issue create command: %s" % e)
 
 
 def delete_intermediate_snapshot(event, context):
-    """Lambda entry point for cleaning up the 2nd intermediate snapshot"""
+    """Lambda entry point for cleaning up the 2nd intermediate snapshot (STEP4)"""
 
     rds = boto3.client('rds', region_name=target_region)
-    snapshot = match_snapshot_event(rds, event)
-    if snapshot:
-        source_rds = get_assumed_role_rds_client(
-            source_account_iam_role_arn, target_region)
-        if is_cluster:
+    source_rds = get_assumed_role_rds_client(
+        source_account_iam_role_arn, target_region)
+
+    # CRON based, used for step 4 (cluster)
+    if is_cluster:
+        snapshots = match_cluster_snapshots(rds)
+        for snapshot in snapshots:
             delete_snapshot(
                 source_rds, snapshot['DBClusterSnapshotIdentifier'])
-        else:
+    # EVENT based, used for step 4 (instance)
+    else:
+        snapshot = match_snapshot_event(rds, event)
+        if snapshot:
             delete_snapshot(source_rds, snapshot['DBSnapshotIdentifier'])

--- a/snapshot-cross-account-replicator/functions/lambda.py
+++ b/snapshot-cross-account-replicator/functions/lambda.py
@@ -124,13 +124,17 @@ def match_snapshot_event(rds, event):
     if is_cluster:
         snapshot = rds.describe_db_cluster_snapshots(
             DBClusterSnapshotIdentifier=snapshot_id)['DBClusterSnapshots'][0]
+        if snapshot['DBClusterInstanceIdentifier'] in instances.split(',') and match_tags(snapshot) and snapshot['Status'] == 'available':
+            return snapshot
+        else:
+            return False
     else:
         snapshot = rds.describe_db_snapshots(
             DBSnapshotIdentifier=snapshot_id)['DBSnapshots'][0]
-    if snapshot['DBClusterIdentifier'] or snapshot['DBInstanceIdentifier'] in instances.split(',') and match_tags(snapshot) and snapshot['Status'] == 'available':
-        return snapshot
-    else:
-        return False
+        if snapshot['DBInstanceIdentifier'] in instances.split(',') and match_tags(snapshot) and snapshot['Status'] == 'available':
+            return snapshot
+        else:
+            return False
 
 
 def cleanup_snapshots(event, context):

--- a/snapshot-cross-account-replicator/iam.tf
+++ b/snapshot-cross-account-replicator/iam.tf
@@ -1,10 +1,12 @@
 locals {
-  source_snapshot_arns       = [for rds in data.aws_db_instance.rds : "arn:aws:rds:${data.aws_region.source.name}:${data.aws_caller_identity.source.account_id}:snapshot:${rds.db_instance_identifier}-*"]
-  intermediate_snapshot_arns = [for rds in data.aws_db_instance.rds : "arn:aws:rds:${data.aws_region.intermediate.name}:${data.aws_caller_identity.source.account_id}:snapshot:${rds.db_instance_identifier}-*"]
-  target_snapshot_arns       = [for rds in data.aws_db_instance.rds : "arn:aws:rds:${data.aws_region.target.name}:${data.aws_caller_identity.target.account_id}:snapshot:${rds.db_instance_identifier}-*"]
+  source_snapshot_arns = [for id in var.rds_instance_ids : "arn:aws:rds:${data.aws_region.source.name}:${data.aws_caller_identity.source.account_id}:${var.is_aurora_cluster ? "cluster-" : ""}snapshot:${id}-*"]
+  
+  intermediate_snapshot_arns = [for id in var.rds_instance_ids : "arn:aws:rds:${data.aws_region.intermediate.name}:${data.aws_caller_identity.source.account_id}:${var.is_aurora_cluster ? "cluster-" : ""}snapshot:${id}-*"]
+
+  target_snapshot_arns = [for id in var.rds_instance_ids : "arn:aws:rds:${data.aws_region.target.name}:${data.aws_caller_identity.target.account_id}:${var.is_aurora_cluster ? "cluster-" : ""}snapshot:${id}-*"]
 
   ### Gather the KMS keys used by the configured RDS instances
-  source_kms_key_ids = compact([for rds in data.aws_db_instance.rds : rds.kms_key_id])
+  source_kms_key_ids = var.is_aurora_cluster ? compact([for rds in data.aws_rds_cluster.rds : rds.kms_key_id]) : compact([for rds in data.aws_db_instance.rds : rds.kms_key_id])
 }
 
 ## IAM resources on the source account
@@ -35,23 +37,30 @@ data "aws_iam_policy_document" "source_lambda_permissions" {
     sid    = "AllowCreateSnapshots"
     effect = "Allow"
     actions = [
+      "rds:CreateDBClusterSnapshot",
       "rds:CreateDBSnapshot",
       "rds:Describe*",
     ]
-    resources = [for rds in data.aws_db_instance.rds : rds.db_instance_arn]
+    resources = is_cluster ? [for rds in data.aws_rds_cluster.rds : rds.arn] : [for rds in data.aws_db_instance.rds : rds.db_instance_arn]
   }
 
   statement {
     sid    = "AllowCreateDeleteAndShareSnapshots"
     effect = "Allow"
     actions = [
+      "rds:CreateDBClusterSnapshot",
+      "rds:DeleteDBClusterSnapshot",
+      "rds:ModifyDBClusterSnapshot",
+      "rds:ModifyDBClusterSnapshotAttribute",
+      "rds:DescribeDBClusterSnapshots",
+      "rds:CopyDBClusterSnapshot",
       "rds:CreateDBSnapshot",
       "rds:DeleteDBSnapshot",
       "rds:ModifyDBSnapshot",
       "rds:ModifyDBSnapshotAttribute",
-      "rds:AddTagsToResource",
       "rds:DescribeDBSnapshots",
-      "rds:CopyDBSnapshot"
+      "rds:CopyDBSnapshot",
+      "rds:AddTagsToResource"
     ]
     resources = concat(local.source_snapshot_arns, local.intermediate_snapshot_arns)
   }
@@ -144,6 +153,8 @@ data "aws_iam_policy_document" "step_4_lambda_permissions" {
     sid    = "AllowDeleteSnapshots"
     effect = "Allow"
     actions = [
+      "rds:DeleteDBClusterSnapshot",
+      "rds:DescribeDBClusterSnapshots",
       "rds:DeleteDBSnapshot",
       "rds:DescribeDBSnapshots"
     ]
@@ -191,6 +202,10 @@ data "aws_iam_policy_document" "target_lambda_permissions" {
   statement {
     effect = "Allow"
     actions = [
+      "rds:DeleteDBClusterSnapshot",
+      "rds:CopyDBClusterSnapshot",
+      "rds:ModifyDBClusterSnapshot",
+      "rds:DescribeDBClusterSnapshots",
       "rds:DeleteDBSnapshot",
       "rds:CopyDBSnapshot",
       "rds:ModifyDBSnapshot",

--- a/snapshot-cross-account-replicator/iam.tf
+++ b/snapshot-cross-account-replicator/iam.tf
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "source_lambda_permissions" {
       "rds:CreateDBSnapshot",
       "rds:Describe*",
     ]
-    resources = is_cluster ? [for rds in data.aws_rds_cluster.rds : rds.arn] : [for rds in data.aws_db_instance.rds : rds.db_instance_arn]
+    resources = var.is_aurora_cluster ? [for rds in data.aws_rds_cluster.rds : rds.arn] : [for rds in data.aws_db_instance.rds : rds.db_instance_arn]
   }
 
   statement {

--- a/snapshot-cross-account-replicator/iam.tf
+++ b/snapshot-cross-account-replicator/iam.tf
@@ -1,6 +1,6 @@
 locals {
   source_snapshot_arns = [for id in var.rds_instance_ids : "arn:aws:rds:${data.aws_region.source.name}:${data.aws_caller_identity.source.account_id}:${var.is_aurora_cluster ? "cluster-" : ""}snapshot:${id}-*"]
-  
+
   intermediate_snapshot_arns = [for id in var.rds_instance_ids : "arn:aws:rds:${data.aws_region.intermediate.name}:${data.aws_caller_identity.source.account_id}:${var.is_aurora_cluster ? "cluster-" : ""}snapshot:${id}-*"]
 
   target_snapshot_arns = [for id in var.rds_instance_ids : "arn:aws:rds:${data.aws_region.target.name}:${data.aws_caller_identity.target.account_id}:${var.is_aurora_cluster ? "cluster-" : ""}snapshot:${id}-*"]
@@ -174,8 +174,8 @@ data "aws_iam_policy_document" "step_4_lambda_permissions" {
   }
 
   statement {
-    sid     = "AllowDescribeAndTagSnapshots"
-    effect  = "Allow"
+    sid    = "AllowDescribeAndTagSnapshots"
+    effect = "Allow"
     actions = [
       "rds:DescribeDBClusterSnapshots",
       "rds:DescribeDBSnapshots",
@@ -240,8 +240,8 @@ data "aws_iam_policy_document" "target_lambda_permissions" {
   }
 
   statement {
-    sid     = "AllowDescribeSnapshots"
-    effect  = "Allow"
+    sid    = "AllowDescribeSnapshots"
+    effect = "Allow"
     actions = [
       "rds:DescribeDBClusterSnapshots",
       "rds:DescribeDBSnapshots",

--- a/snapshot-cross-account-replicator/iam.tf
+++ b/snapshot-cross-account-replicator/iam.tf
@@ -66,6 +66,18 @@ data "aws_iam_policy_document" "source_lambda_permissions" {
   }
 
   statement {
+    sid    = "AllowDescribeAndTagSnapshots"
+    effect = "Allow"
+    actions = [
+      "rds:DescribeDBClusterSnapshots",
+      "rds:DescribeDBSnapshots",
+      "rds:ListTagsForResource",
+      "rds:AddTagsToResource"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
     sid       = "AllowAssumeRoleInTargetAccount"
     effect    = "Allow"
     actions   = ["sts:AssumeRole"]
@@ -159,6 +171,18 @@ data "aws_iam_policy_document" "step_4_lambda_permissions" {
       "rds:DescribeDBSnapshots"
     ]
     resources = concat(local.source_snapshot_arns, local.intermediate_snapshot_arns)
+  }
+
+  statement {
+    sid    = "AllowDescribeAndTagSnapshots"
+    effect = "Allow"
+    actions = [
+      "rds:DescribeDBClusterSnapshots",
+      "rds:DescribeDBSnapshots",
+      "rds:ListTagsForResource",
+      "rds:AddTagsToResource"
+    ]
+    resources = ["*"]
   }
 }
 

--- a/snapshot-cross-account-replicator/iam.tf
+++ b/snapshot-cross-account-replicator/iam.tf
@@ -174,8 +174,8 @@ data "aws_iam_policy_document" "step_4_lambda_permissions" {
   }
 
   statement {
-    sid    = "AllowDescribeAndTagSnapshots"
-    effect = "Allow"
+    sid     = "AllowDescribeAndTagSnapshots"
+    effect  = "Allow"
     actions = [
       "rds:DescribeDBClusterSnapshots",
       "rds:DescribeDBSnapshots",
@@ -240,10 +240,14 @@ data "aws_iam_policy_document" "target_lambda_permissions" {
   }
 
   statement {
+    sid     = "AllowDescribeSnapshots"
     effect  = "Allow"
-    actions = ["rds:DescribeDbSnapshots"]
-    ### This is needed for the cleanup lambda function to be able to describe all snapshots from an instance
-    resources = [for id in var.rds_instance_ids : "arn:aws:rds:${data.aws_region.target.name}:${data.aws_caller_identity.target.account_id}:${var.is_aurora_cluster ? "cluster" : "db"}:${id}"]
+    actions = [
+      "rds:DescribeDBClusterSnapshots",
+      "rds:DescribeDBSnapshots",
+      "rds:ListTagsForResource"
+    ]
+    resources = ["*"]
   }
 
   statement {

--- a/snapshot-cross-account-replicator/iam.tf
+++ b/snapshot-cross-account-replicator/iam.tf
@@ -219,7 +219,7 @@ data "aws_iam_policy_document" "target_lambda_permissions" {
     effect  = "Allow"
     actions = ["rds:DescribeDbSnapshots"]
     ### This is needed for the cleanup lambda function to be able to describe all snapshots from an instance
-    resources = [for id in var.rds_instance_ids : "arn:aws:rds:${data.aws_region.target.name}:${data.aws_caller_identity.target.account_id}:db:${id}"]
+    resources = [for id in var.rds_instance_ids : "arn:aws:rds:${data.aws_region.target.name}:${data.aws_caller_identity.target.account_id}:${var.is_aurora_cluster ? "cluster" : "db"}:${id}"]
   }
 
   statement {

--- a/snapshot-cross-account-replicator/lambda_source_account.tf
+++ b/snapshot-cross-account-replicator/lambda_source_account.tf
@@ -129,7 +129,7 @@ resource "aws_lambda_function" "step_3" {
 resource "aws_cloudwatch_event_rule" "invoke_step_3_lambda" {
   provider            = aws.intermediate
   description         = "Triggers lambda function ${aws_lambda_function.step_3.function_name}"
-  event_pattern       = ! var.is_aurora_cluster ? local.invoke_step_3_lambda_event_pattern_instance : null
+  event_pattern       = !var.is_aurora_cluster ? local.invoke_step_3_lambda_event_pattern_instance : null
   schedule_expression = var.is_aurora_cluster ? "cron(*/30 * * * ? *)" : null
 }
 

--- a/snapshot-cross-account-replicator/lambda_source_account.tf
+++ b/snapshot-cross-account-replicator/lambda_source_account.tf
@@ -154,7 +154,7 @@ resource "aws_cloudwatch_event_rule" "invoke_step_3_lambda" {
   }
 }
 EOF
-}
+} # TODO: event
 
 resource "aws_cloudwatch_event_target" "invoke_step_3_lambda" {
   provider = aws.intermediate

--- a/snapshot-cross-account-replicator/lambda_source_account.tf
+++ b/snapshot-cross-account-replicator/lambda_source_account.tf
@@ -123,12 +123,14 @@ resource "aws_lambda_function" "step_3" {
   }
 }
 
-#### This EventBridge event rule filters RDS snapshot copy events
-#### relevant to the configured RDS instances only
+#### This EventBridge event rule either filters RDS snapshot copy events
+#### relevant to the configured RDS instances only (for instances)
+#### OR in case of cluster trigger on a CRON schedule evry 30 min
 resource "aws_cloudwatch_event_rule" "invoke_step_3_lambda" {
-  provider      = aws.intermediate
-  description   = "Triggers lambda function ${aws_lambda_function.step_3.function_name}"
-  event_pattern = var.is_aurora_cluster ? local.invoke_step_3_lambda_event_pattern_cluster : local.invoke_step_3_lambda_event_pattern_instance
+  provider            = aws.intermediate
+  description         = "Triggers lambda function ${aws_lambda_function.step_3.function_name}"
+  event_pattern       = ! var.is_aurora_cluster ? local.invoke_step_3_lambda_event_pattern_instance : null
+  schedule_expression = var.is_aurora_cluster ? "cron(*/30 * * * ? *)" : null
 }
 
 resource "aws_cloudwatch_event_target" "invoke_step_3_lambda" {

--- a/snapshot-cross-account-replicator/lambda_source_account.tf
+++ b/snapshot-cross-account-replicator/lambda_source_account.tf
@@ -77,19 +77,7 @@ resource "aws_lambda_function" "step_2" {
 resource "aws_cloudwatch_event_rule" "invoke_step_2_lambda" {
   provider      = aws.source
   description   = "Triggers lambda function ${aws_lambda_function.step_2.function_name}"
-  event_pattern = <<EOF
-{
-  "source": ["aws.rds"],
-  "detail-type": ["RDS DB Snapshot Event"],
-  "region": ["${data.aws_region.source.name}"],
-  "detail": {
-    "SourceIdentifier": ${jsonencode(local.event_rule_pattern)},
-    "Message": ["Manual snapshot created"],
-    "EventCategories": ["creation"],
-    "SourceType": ["SNAPSHOT"]
-  }
-}
-EOF
+  event_pattern = var.is_aurora_cluster ? local.invoke_step_2_lambda_event_pattern_cluster : local.invoke_step_2_lambda_event_pattern_instance
 }
 
 resource "aws_cloudwatch_event_target" "invoke_step_2_lambda" {
@@ -140,21 +128,8 @@ resource "aws_lambda_function" "step_3" {
 resource "aws_cloudwatch_event_rule" "invoke_step_3_lambda" {
   provider      = aws.intermediate
   description   = "Triggers lambda function ${aws_lambda_function.step_3.function_name}"
-  event_pattern = <<EOF
-{
-  "source": ["aws.rds"],
-  "detail-type": ["RDS DB Snapshot Event"],
-  "region": ["${data.aws_region.intermediate.name}"],
-  "detail": {
-    "SourceIdentifier": ${jsonencode(local.event_rule_pattern)},
-    "Message": [{"prefix": "Finished copy of snapshot "}],
-    "EventCategories": ["notification"],
-    "SourceType": ["SNAPSHOT"],
-    "EventID": ["RDS-EVENT-0060"]
-  }
+  event_pattern = var.is_aurora_cluster ? local.invoke_step_3_lambda_event_pattern_cluster : local.invoke_step_3_lambda_event_pattern_instance
 }
-EOF
-} # TODO: event
 
 resource "aws_cloudwatch_event_target" "invoke_step_3_lambda" {
   provider = aws.intermediate

--- a/snapshot-cross-account-replicator/lambda_target_account.tf
+++ b/snapshot-cross-account-replicator/lambda_target_account.tf
@@ -43,7 +43,7 @@ resource "aws_cloudwatch_event_rule" "invoke_step_4_lambda" {
   }
 }
 EOF
-}
+} # TODO EVENT
 
 resource "aws_cloudwatch_event_target" "invoke_step_4_lambda" {
   provider = aws.target

--- a/snapshot-cross-account-replicator/lambda_target_account.tf
+++ b/snapshot-cross-account-replicator/lambda_target_account.tf
@@ -27,9 +27,10 @@ resource "aws_lambda_function" "step_4" {
 ## This event will be triggered when the final snapshot has been copied to the target account
 ## so the intermediate snapshot can be safely deleted
 resource "aws_cloudwatch_event_rule" "invoke_step_4_lambda" {
-  provider      = aws.target
-  description   = "Triggers lambda function ${aws_lambda_function.step_4.function_name}"
-  event_pattern = local.invoke_step_4_lambda_event_pattern_instance  # TODO for cluster mode
+  provider            = aws.target
+  description         = "Triggers lambda function ${aws_lambda_function.step_4.function_name}"
+  event_pattern       = ! var.is_aurora_cluster ? local.invoke_step_4_lambda_event_pattern_instance : null
+  schedule_expression = var.is_aurora_cluster ? "cron(*/30 * * * ? *)" : null
 }
 
 resource "aws_cloudwatch_event_target" "invoke_step_4_lambda" {

--- a/snapshot-cross-account-replicator/lambda_target_account.tf
+++ b/snapshot-cross-account-replicator/lambda_target_account.tf
@@ -29,21 +29,8 @@ resource "aws_lambda_function" "step_4" {
 resource "aws_cloudwatch_event_rule" "invoke_step_4_lambda" {
   provider      = aws.target
   description   = "Triggers lambda function ${aws_lambda_function.step_4.function_name}"
-  event_pattern = <<EOF
-{
-  "source": ["aws.rds"],
-  "detail-type": ["RDS DB Snapshot Event"],
-  "region": ["${data.aws_region.intermediate.name}"],
-  "detail": {
-    "SourceIdentifier": ${jsonencode(local.event_rule_pattern)},
-    "Message": [{"prefix": "Finished copy of snapshot "}],
-    "EventCategories": ["notification"],
-    "SourceType": ["SNAPSHOT"],
-    "EventID": ["RDS-EVENT-0197"]
-  }
+  event_pattern = var.is_aurora_cluster ? local.invoke_step_4_lambda_event_pattern_cluster : local.invoke_step_4_lambda_event_pattern_instance
 }
-EOF
-} # TODO EVENT
 
 resource "aws_cloudwatch_event_target" "invoke_step_4_lambda" {
   provider = aws.target

--- a/snapshot-cross-account-replicator/lambda_target_account.tf
+++ b/snapshot-cross-account-replicator/lambda_target_account.tf
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "step_4" {
 resource "aws_cloudwatch_event_rule" "invoke_step_4_lambda" {
   provider      = aws.target
   description   = "Triggers lambda function ${aws_lambda_function.step_4.function_name}"
-  event_pattern = var.is_aurora_cluster ? local.invoke_step_4_lambda_event_pattern_cluster : local.invoke_step_4_lambda_event_pattern_instance
+  event_pattern = local.invoke_step_4_lambda_event_pattern_instance  # TODO for cluster mode
 }
 
 resource "aws_cloudwatch_event_target" "invoke_step_4_lambda" {

--- a/snapshot-cross-account-replicator/lambda_target_account.tf
+++ b/snapshot-cross-account-replicator/lambda_target_account.tf
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "step_4" {
 resource "aws_cloudwatch_event_rule" "invoke_step_4_lambda" {
   provider            = aws.target
   description         = "Triggers lambda function ${aws_lambda_function.step_4.function_name}"
-  event_pattern       = ! var.is_aurora_cluster ? local.invoke_step_4_lambda_event_pattern_instance : null
+  event_pattern       = !var.is_aurora_cluster ? local.invoke_step_4_lambda_event_pattern_instance : null
   schedule_expression = var.is_aurora_cluster ? "cron(*/30 * * * ? *)" : null
 }
 

--- a/snapshot-cross-account-replicator/main.tf
+++ b/snapshot-cross-account-replicator/main.tf
@@ -70,6 +70,95 @@ locals {
   event_rule_pattern = [for id in var.rds_instance_ids : {
     prefix = "${id}-"
   }]
+
+  invoke_step_2_lambda_event_pattern_cluster = <<EOF
+{
+  "detail-type": ["RDS DB Cluster Snapshot Event"],
+  "source": ["aws.rds"],
+  "region": ["${data.aws_region.source.name}"],
+  "detail": {
+    "EventCategories": ["backup"],
+    "SourceType": ["CLUSTER_SNAPSHOT"],
+    "Message": ["Manual cluster snapshot created"],
+    "SourceIdentifier": ${jsonencode(local.event_rule_pattern)},
+    "EventID": ["RDS-EVENT-0075"]
+  }
+}
+EOF
+
+  invoke_step_2_lambda_event_pattern_instance = <<EOF
+{
+  "source": ["aws.rds"],
+  "detail-type": ["RDS DB Snapshot Event"],
+  "region": ["${data.aws_region.source.name}"],
+  "detail": {
+    "SourceIdentifier": ${jsonencode(local.event_rule_pattern)},
+    "Message": ["Manual snapshot created"],
+    "EventCategories": ["creation"],
+    "SourceType": ["SNAPSHOT"]
+  }
+}
+EOF
+
+  invoke_step_3_lambda_event_pattern_cluster = <<EOF
+{
+  "detail-type": ["RDS DB Cluster Snapshot Event"],
+  "source": ["aws.rds"],
+  "region": ["${data.aws_region.intermediate.name}"],
+  "detail": {
+    "EventCategories": ["notification"],
+    "SourceType": ["CLUSTER_SNAPSHOT"],
+    "Message": [{"prefix": "TODO "}],
+    "SourceIdentifier": ${jsonencode(local.event_rule_pattern)},
+    "EventID": ["TODO"]
+  }
+}
+EOF
+
+  invoke_step_3_lambda_event_pattern_instance = <<EOF
+{
+  "source": ["aws.rds"],
+  "detail-type": ["RDS DB Snapshot Event"],
+  "region": ["${data.aws_region.intermediate.name}"],
+  "detail": {
+    "SourceIdentifier": ${jsonencode(local.event_rule_pattern)},
+    "Message": [{"prefix": "Finished copy of snapshot "}],
+    "EventCategories": ["notification"],
+    "SourceType": ["SNAPSHOT"],
+    "EventID": ["RDS-EVENT-0060"]
+  }
+}
+EOF
+
+  invoke_step_4_lambda_event_pattern_cluster = <<EOF
+{
+  "detail-type": ["RDS DB Cluster Snapshot Event"],
+  "source": ["aws.rds"],
+  "region": ["${data.aws_region.intermediate.name}"],
+  "detail": {
+    "EventCategories": ["notification"],
+    "SourceType": ["CLUSTER_SNAPSHOT"],
+    "Message": [{"prefix": "TODO "}],
+    "SourceIdentifier": ${jsonencode(local.event_rule_pattern)},
+    "EventID": ["TODO"]
+  }
+}
+EOF
+
+  invoke_step_4_lambda_event_pattern_instance = <<EOF
+{
+  "source": ["aws.rds"],
+  "detail-type": ["RDS DB Snapshot Event"],
+  "region": ["${data.aws_region.intermediate.name}"],
+  "detail": {
+    "SourceIdentifier": ${jsonencode(local.event_rule_pattern)},
+    "Message": [{"prefix": "Finished copy of snapshot "}],
+    "EventCategories": ["notification"],
+    "SourceType": ["SNAPSHOT"],
+    "EventID": ["RDS-EVENT-0197"]
+  }
+}
+EOF
 }
 
 data "archive_file" "lambda_zip" {

--- a/snapshot-cross-account-replicator/main.tf
+++ b/snapshot-cross-account-replicator/main.tf
@@ -100,21 +100,6 @@ EOF
 }
 EOF
 
-  invoke_step_3_lambda_event_pattern_cluster = <<EOF
-{
-  "detail-type": ["RDS DB Cluster Snapshot Event"],
-  "source": ["aws.rds"],
-  "region": ["${data.aws_region.intermediate.name}"],
-  "detail": {
-    "EventCategories": ["notification"],
-    "SourceType": ["CLUSTER_SNAPSHOT"],
-    "Message": [{"prefix": "TODO "}],
-    "SourceIdentifier": ${jsonencode(local.event_rule_pattern)},
-    "EventID": ["TODO"]
-  }
-}
-EOF
-
   invoke_step_3_lambda_event_pattern_instance = <<EOF
 {
   "source": ["aws.rds"],
@@ -126,21 +111,6 @@ EOF
     "EventCategories": ["notification"],
     "SourceType": ["SNAPSHOT"],
     "EventID": ["RDS-EVENT-0060"]
-  }
-}
-EOF
-
-  invoke_step_4_lambda_event_pattern_cluster = <<EOF
-{
-  "detail-type": ["RDS DB Cluster Snapshot Event"],
-  "source": ["aws.rds"],
-  "region": ["${data.aws_region.intermediate.name}"],
-  "detail": {
-    "EventCategories": ["notification"],
-    "SourceType": ["CLUSTER_SNAPSHOT"],
-    "Message": [{"prefix": "TODO "}],
-    "SourceIdentifier": ${jsonencode(local.event_rule_pattern)},
-    "EventID": ["TODO"]
   }
 }
 EOF

--- a/snapshot-cross-account-replicator/main.tf
+++ b/snapshot-cross-account-replicator/main.tf
@@ -35,13 +35,13 @@ data "aws_region" "target" {
 
 data "aws_rds_cluster" "rds" {
   provider           = aws.source
-  for_each           = var.is_aurora_cluster ? toset(var.rds_instance_ids) : 0
+  for_each           = var.is_aurora_cluster ? toset(var.rds_instance_ids) : []
   cluster_identifier = each.key
 }
 
 data "aws_db_instance" "rds" {
   provider               = aws.source
-  for_each               = ! var.is_aurora_cluster ? toset(var.rds_instance_ids) : 0
+  for_each               = ! var.is_aurora_cluster ? toset(var.rds_instance_ids) : []
   db_instance_identifier = each.key
 }
 

--- a/snapshot-cross-account-replicator/main.tf
+++ b/snapshot-cross-account-replicator/main.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws = {
-      version = ">= 3.61.0"
+      version = "~> 3.61"
       configuration_aliases = [
         aws.source,
         aws.intermediate,
@@ -41,7 +41,7 @@ data "aws_rds_cluster" "rds" {
 
 data "aws_db_instance" "rds" {
   provider               = aws.source
-  for_each               = ! var.is_aurora_cluster ? toset(var.rds_instance_ids) : []
+  for_each               = !var.is_aurora_cluster ? toset(var.rds_instance_ids) : []
   db_instance_identifier = each.key
 }
 

--- a/snapshot-cross-account-replicator/variables.tf
+++ b/snapshot-cross-account-replicator/variables.tf
@@ -3,8 +3,14 @@ variable "name" {
   type        = string
 }
 
+variable "is_aurora_cluster" {
+  description = "Whether we're backing up Aurora clusters instead of RDS instances"
+  type        = bool
+  default     = false
+}
+
 variable "rds_instance_ids" {
-  description = "List of IDs of the RDS instances to back up"
+  description = "List of IDs of the RDS instances to back up. If using Aurora, provide the cluster IDs instead"
   type        = list(string)
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
RDS Aurora uses a different API than regular RDS instances. Rework the cross-account-replicator to include Aurora clusters.

Unfortunately Aurora doesn't provide "Finished copy of snapshot" events like Instance-based RDS does (why AWS :( ), so instead in cluster mode the step 3 and 4 lambda's run on cron schedule instead of event based.

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/skyscrapers/engineering/issues/736

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the PR process as described [here](https://github.com/skyscrapers/documentation/blob/master/coding_guidelines/git.md#pull-requests)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
