### PR TITLE
Allow replicas subnet to be not specified

### DIFF
--- a/rds-replica/main.tf
+++ b/rds-replica/main.tf
@@ -1,5 +1,5 @@
 resource "aws_db_subnet_group" "rds" {
-  count       = var.number_of_replicas > 0 ? 1 : 0
+  count       = var.number_of_replicas > 0 ? var.subnets == null ? 0 : 1 : 0
   name        = length(var.name) == 0 ? "${var.project}-${var.environment}${var.tag}-rds-replica" : var.name
   description = "The group of subnets"
   subnet_ids  = var.subnets
@@ -18,7 +18,7 @@ resource "aws_db_instance" "rds" {
   vpc_security_group_ids          = [aws_security_group.sg_rds[0].id]
   replicate_source_db             = var.replicate_source_db
   publicly_accessible             = var.publicly_accessible
-  db_subnet_group_name            = aws_db_subnet_group.rds[0].id
+  db_subnet_group_name            = var.subnets == null ? null : aws_db_subnet_group.rds[0].id
   storage_encrypted               = var.storage_encrypted
   allocated_storage               = var.allocated_storage
   max_allocated_storage           = var.max_allocated_storage


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->

Allowing RDS replicas to have null subnet group 

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/skyscrapers/q16/issues/162
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Was getting error from terraform on starting a replica while specifying a subnet group, looks to be related to this upstream issue: https://github.com/hashicorp/terraform-provider-aws/issues/528 

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
already implemented and worked as expected when set to null as part of a DRP test

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the PR process as described [here](https://github.com/skyscrapers/documentation/blob/master/coding_guidelines/git.md#pull-requests)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
