### PR TITLE
Expose identifier in order to work with AWS provider v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ No modules.
 | <a name="output_rds_address"></a> [rds\_address](#output\_rds\_address)                                        | The hostname of the RDS instance          |
 | <a name="output_rds_arn"></a> [rds\_arn](#output\_rds\_arn)                                                    | The arn of the RDS instance               |
 | <a name="output_rds_id"></a> [rds\_id](#output\_rds\_id)                                                       | The id of the RDS instance                |
+| <a name="output_rds_identifier"></a> [rds\_identifier](#output\_rds\_identifier)                               | The identifier of the RDS instance        |
 | <a name="output_rds_port"></a> [rds\_port](#output\_rds\_port)                                                 | The port of the RDS instance              |
 | <a name="output_rds_sg_id"></a> [rds\_sg\_id](#output\_rds\_sg\_id)                                            | The security group id of the RDS instance |
 

--- a/rds/outputs.tf
+++ b/rds/outputs.tf
@@ -10,7 +10,12 @@ output "rds_address" {
 
 output "rds_id" {
   description = "The id of the RDS instance"
-  value       = aws_db_instance.rds.id
+  value       = aws_db_instance.rds.resource_id
+}
+
+output "rds_identifier" {
+  description = "The identifier of the RDS instance"
+  value       = aws_db_instance.rds.identifier
 }
 
 output "rds_arn" {

--- a/rds/outputs.tf
+++ b/rds/outputs.tf
@@ -10,7 +10,7 @@ output "rds_address" {
 
 output "rds_id" {
   description = "The id of the RDS instance"
-  value       = aws_db_instance.rds.resource_id
+  value       = aws_db_instance.rds.id
 }
 
 output "rds_identifier" {

--- a/rds/versions.tf
+++ b/rds/versions.tf
@@ -1,4 +1,10 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 1.0, < 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
Needed to mitigate https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#500-may-25-2023:

> resource/aws_db_instance: The change of what id is, namely, a DBI Resource ID now versus DB Identifier previously, has far-reaching consequences. Configurations that refer to, for example, aws_db_instance.example.id will now have errors and must be changed to use identifier instead, for example, aws_db_instance.example.identifier (https://github.com/hashicorp/terraform-provider-aws/issues/31232)

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually 

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the PR process as described [here](https://github.com/skyscrapers/documentation/blob/master/coding_guidelines/git.md#pull-requests)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
